### PR TITLE
rewrote plugin spec function AiDacrateChanged

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -299,6 +299,15 @@ EXPORT void CALL AiDacrateChanged (int  SystemType) {
 		return;
 
 	Dacrate = *AudioInfo.AI_DACRATE_REG & 0x00003FFF;
+#ifdef _DEBUG
+	if (Dacrate != *AudioInfo.AI_DACRATE_REG)
+		MessageBox(
+			NULL,
+			"Unknown/reserved bits in AI_DACRATE_REG set.",
+			"Warning",
+			MB_ICONWARNING
+		);
+#endif
 	switch (SystemType) {
 		default         :  MessageBox(NULL, "Invalid SystemType.", NULL, MB_ICONERROR);
 		case SYSTEM_NTSC:  video_clock = 48681812; break;

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -300,6 +300,7 @@ EXPORT void CALL AiDacrateChanged (int  SystemType) {
 
 	Dacrate = *AudioInfo.AI_DACRATE_REG;
 	switch (SystemType) {
+		default         :  MessageBox(NULL, "Invalid SystemType.", NULL, MB_ICONERROR);
 		case SYSTEM_NTSC:  video_clock = 48681812; break;
 		case SYSTEM_PAL :  video_clock = 49656530; break;
 		case SYSTEM_MPAL:  video_clock = 48628316; break;

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -293,17 +293,18 @@ EXPORT void CALL RomClosed (void){
 }
 
 EXPORT void CALL AiDacrateChanged (int  SystemType) {
-	DWORD Frequency;
+	DWORD Frequency, video_clock;
 
 	if (Dacrate == *AudioInfo.AI_DACRATE_REG)
 		return;
 
 	Dacrate = *AudioInfo.AI_DACRATE_REG;
 	switch (SystemType) {
-		case SYSTEM_NTSC: Frequency = 48681812 / (Dacrate + 1); break;
-		case SYSTEM_PAL:  Frequency = 49656530 / (Dacrate + 1); break;
-		case SYSTEM_MPAL: Frequency = 48628316 / (Dacrate + 1); break;
+		case SYSTEM_NTSC:  video_clock = 48681812; break;
+		case SYSTEM_PAL :  video_clock = 49656530; break;
+		case SYSTEM_MPAL:  video_clock = 48628316; break;
 	}
+	Frequency = video_clock / (Dacrate + 1);
 	if (audioIsInitialized == TRUE) snd.SetFrequency(Frequency);
 }
 

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -298,7 +298,7 @@ EXPORT void CALL AiDacrateChanged (int  SystemType) {
 	if (Dacrate == *AudioInfo.AI_DACRATE_REG)
 		return;
 
-	Dacrate = *AudioInfo.AI_DACRATE_REG;
+	Dacrate = *AudioInfo.AI_DACRATE_REG & 0x00003FFF;
 	switch (SystemType) {
 		default         :  MessageBox(NULL, "Invalid SystemType.", NULL, MB_ICONERROR);
 		case SYSTEM_NTSC:  video_clock = 48681812; break;

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -294,15 +294,17 @@ EXPORT void CALL RomClosed (void){
 
 EXPORT void CALL AiDacrateChanged (int  SystemType) {
 	DWORD Frequency;
-	if (Dacrate != *AudioInfo.AI_DACRATE_REG) {
-		Dacrate = *AudioInfo.AI_DACRATE_REG;
-		switch (SystemType) {
-			case SYSTEM_NTSC: Frequency = 48681812 / (Dacrate + 1); break;
-			case SYSTEM_PAL:  Frequency = 49656530 / (Dacrate + 1); break;
-			case SYSTEM_MPAL: Frequency = 48628316 / (Dacrate + 1); break;
-		}
-		if (audioIsInitialized == TRUE) snd.SetFrequency(Frequency);
+
+	if (Dacrate == *AudioInfo.AI_DACRATE_REG)
+		return;
+
+	Dacrate = *AudioInfo.AI_DACRATE_REG;
+	switch (SystemType) {
+		case SYSTEM_NTSC: Frequency = 48681812 / (Dacrate + 1); break;
+		case SYSTEM_PAL:  Frequency = 49656530 / (Dacrate + 1); break;
+		case SYSTEM_MPAL: Frequency = 48628316 / (Dacrate + 1); break;
 	}
+	if (audioIsInitialized == TRUE) snd.SetFrequency(Frequency);
 }
 
 EXPORT void CALL AiLenChanged (void){


### PR DESCRIPTION
This was all zilmar's original code for the function really; like every audio plugin uses it.  I just felt like it could be more readable to remove any potential distraction from things like, a bug in the main CPU emulator passing an invalid SystemType to the function, or oddball values of AI_DACRATE_REG.  I also felt like it may be more readable to invert the if { } else { } branch predictor so that the entire, much larger else { } bit doesn't all have to be indented an extra tab.  (See very first commit.)

Mostly a bunch of idealistic, minor changes, though I think it could help document some bits more.

So, for a few years now, I've always been curious what would happen on real hardware if a game managed in some way to access the reserved/unused bits of RCP registers.  For example, it's established that AI_DACRATE_REG has usually only the low 14 bits of merit [13..0].  I imagine that setting anything else shouldn't have an effect, but, just in case of potentially unexplored possibilities like that, I felt like adding some verbosity there.
