### PR TITLE
got the plugin to compile in MinGW GCC/G++

### DIFF
--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -247,9 +247,6 @@ void ENVMIXER () {
 				mov eax, dword ptr [LRamp];
 				imul ecx;
 				shrd eax, edx, 16;
-				//shl edx, 16;
-				//shr eax, 16;
-				//add eax, edx;
 				mov dword ptr [LAdderEnd], eax;
 				mov eax, dword ptr [LAdderStart];
 				mov dword ptr [LAcc], eax;
@@ -272,9 +269,7 @@ void ENVMIXER () {
 				mov ecx, dword ptr [RAdderEnd];
 				mov eax, dword ptr [RRamp];
 				imul ecx;
-				shl edx, 16;
-				shr eax, 16;
-				add eax, edx;
+				shrd eax, edx, 16;
 				mov dword ptr [RAdderEnd], eax;
 				mov eax, dword ptr [RAdderStart];
 				mov dword ptr [RAcc], eax;

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -531,7 +531,7 @@ void RESAMPLE () {
 	}
 
 	if ((Flags & 0x2))
-		__asm int 3;
+		x86_interrupt();
 
 	for(int i=0;i < ((AudioCount+0xf)&0xFFF0)/2;i++)	{
 		//location = (((Accum * 0x40) >> 0x10) * 8);

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -952,7 +952,7 @@ void LOADADPCM () { // Loads an ADPCM table - Works 100% Now 03-13-01
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 #ifdef _DEBUG
 	if (v0 > (1024*1024*8))
-		v0 = (t9 & 0xffffff);*/
+		v0 = (t9 & 0xffffff);
 	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
 	assert ((k0&0xffff) <= 0x80);
 #endif

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -242,6 +242,7 @@ void ENVMIXER () {
 	for (int y = 0; y < AudioCount; y += 0x10) {
 
 		if (LAdderStart != LTrg) {
+#if defined(_MSC_VER)
 			__asm {
 				mov ecx, dword ptr [LAdderEnd];
 				mov eax, dword ptr [LRamp];
@@ -255,6 +256,22 @@ void ENVMIXER () {
 				sar ecx, 3;
 				mov dword ptr [LVol], ecx;
 			}
+#else
+			__asm__(
+				".intel_syntax;"
+				"MOV     ecx, DWORD PTR [LAdderEnd];"
+				"MOV     eax, DWORD PTR [LRamp];"
+				"IMUL    ecx;"
+				"SHRD    eax, edx, 16;"
+				"MOV     DWORD PTR [LAdderEnd], eax;"
+				"MOV     eax, DWORD PTR [LAdderStart];"
+				"MOV     DWORD PTR [LAcc], eax;"
+				"MOV     DWORD PTR [LAdderStart], ecx;"
+				"SUB     ecx, eax;"
+				"SAR     ecx, 3;"
+				"MOV     DWORD PTR [LVol], ecx;"
+			);
+#endif
 			//LAcc = LAdderStart;
 			//LVol = (LAdderEnd - LAdderStart) >> 3;
 			//LAdderEnd   = ((s64)LAdderEnd * (s64)LRamp) >> 16;
@@ -265,6 +282,7 @@ void ENVMIXER () {
 		}
 
 		if (RAdderStart != RTrg) {
+#if defined(_MSC_VER)
 			__asm {
 				mov ecx, dword ptr [RAdderEnd];
 				mov eax, dword ptr [RRamp];
@@ -278,6 +296,22 @@ void ENVMIXER () {
 				sar ecx, 3;
 				mov dword ptr [RVol], ecx;
 			}
+#else
+			__asm__(
+				".intel_syntax;"
+				"MOV     ecx, DWORD PTR [RAdderEnd];"
+				"MOV     eax, DWORD PTR [RRamp];"
+				"IMUL    ecx;"
+				"SHRD    eax, edx, 16;"
+				"MOV     DWORD PTR [RAdderEnd], eax;"
+				"MOV     eax, DWORD PTR [RAdderStart];"
+				"MOV     DWORD PTR [RAcc], eax;"
+				"MOV     DWORD PTR [RAdderStart], ecx;"
+				"SUB     ecx, eax;"
+				"SAR     ecx, 3;"
+				"MOV     DWORD PTR [RVol], ecx;"
+			);
+#endif
 			//RAcc = RAdderStart;
 			//RVol = (RAdderEnd - RAdderStart) >> 3;
 			//RAdderEnd   = ((s64)RAdderEnd * (s64)RRamp) >> 16;

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -242,7 +242,7 @@ void ENVMIXER () {
 	for (int y = 0; y < AudioCount; y += 0x10) {
 
 		if (LAdderStart != LTrg) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_WIN32) && !defined(_WIN64)
 			__asm {
 				mov ecx, dword ptr [LAdderEnd];
 				mov eax, dword ptr [LRamp];
@@ -257,20 +257,14 @@ void ENVMIXER () {
 				mov dword ptr [LVol], ecx;
 			}
 #else
-			__asm__(
-				".intel_syntax;"
-				"MOV     ecx, DWORD PTR [LAdderEnd];"
-				"MOV     eax, DWORD PTR [LRamp];"
-				"IMUL    ecx;"
-				"SHRD    eax, edx, 16;"
-				"MOV     DWORD PTR [LAdderEnd], eax;"
-				"MOV     eax, DWORD PTR [LAdderStart];"
-				"MOV     DWORD PTR [LAcc], eax;"
-				"MOV     DWORD PTR [LAdderStart], ecx;"
-				"SUB     ecx, eax;"
-				"SAR     ecx, 3;"
-				"MOV     DWORD PTR [LVol], ecx;"
-			);
+			s64 product, product_shifted;
+
+			product = (s64)LRamp * (s64)LAdderEnd;
+			product_shifted = product >> 16;
+			LAcc = LAdderStart;
+			LAdderStart = LAdderEnd;
+			LVol = (LAdderEnd - LAcc) / 8;
+			LAdderEnd = (s32)(product_shifted & 0xFFFFFFFFul);
 #endif
 			//LAcc = LAdderStart;
 			//LVol = (LAdderEnd - LAdderStart) >> 3;
@@ -282,7 +276,7 @@ void ENVMIXER () {
 		}
 
 		if (RAdderStart != RTrg) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_WIN32) && !defined(_WIN64)
 			__asm {
 				mov ecx, dword ptr [RAdderEnd];
 				mov eax, dword ptr [RRamp];
@@ -297,20 +291,14 @@ void ENVMIXER () {
 				mov dword ptr [RVol], ecx;
 			}
 #else
-			__asm__(
-				".intel_syntax;"
-				"MOV     ecx, DWORD PTR [RAdderEnd];"
-				"MOV     eax, DWORD PTR [RRamp];"
-				"IMUL    ecx;"
-				"SHRD    eax, edx, 16;"
-				"MOV     DWORD PTR [RAdderEnd], eax;"
-				"MOV     eax, DWORD PTR [RAdderStart];"
-				"MOV     DWORD PTR [RAcc], eax;"
-				"MOV     DWORD PTR [RAdderStart], ecx;"
-				"SUB     ecx, eax;"
-				"SAR     ecx, 3;"
-				"MOV     DWORD PTR [RVol], ecx;"
-			);
+			s64 product, product_shifted;
+
+			product = (s64)RRamp * (s64)RAdderEnd;
+			product_shifted = product >> 16;
+			RAcc = RAdderStart;
+			RAdderStart = RAdderEnd;
+			RVol = (RAdderEnd - RAcc) / 8;
+			RAdderEnd = (s32)(product_shifted & 0xFFFFFFFFul);
 #endif
 			//RAcc = RAdderStart;
 			//RVol = (RAdderEnd - RAdderStart) >> 3;

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -916,13 +916,13 @@ void SEGMENT () { // Should work
 
 void SETBUFF () { // Should work ;-)
 	if ((k0 >> 0x10) & 0x8) { // A_AUX - Auxillary Sound Buffer Settings
-		AudioAuxA		= u16(k0);
-		AudioAuxC		= u16((t9 >> 0x10));
-		AudioAuxE		= u16(t9);
+		AudioAuxA       = (u16)(k0);
+		AudioAuxC       = (u16)((t9 >> 0x10));
+		AudioAuxE       = (u16)(t9);
 	} else {		// A_MAIN - Main Sound Buffer Settings
-		AudioInBuffer   = u16(k0); // 0x00
-		AudioOutBuffer	= u16((t9 >> 0x10)); // 0x02
-		AudioCount		= u16(t9); // 0x04
+		AudioInBuffer   = (u16)(k0);           // 0x00
+		AudioOutBuffer  = (u16)((t9 >> 0x10)); // 0x02
+		AudioCount      = (u16)(t9);           // 0x04
 	}
 }
 

--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -903,10 +903,9 @@ void DMEMMOVE () { // Doesn't sound just right?... will fix when HLE is ready - 
 		return;
 	v0 = (k0 & 0xFFFF);
 	v1 = (t9 >> 0x10);
-#ifdef _DEBUG
-	assert((v1 & 0x3) == 0);
-	assert((v0 & 0x3) == 0);
-#endif
+	//assert((v1 & 0x3) == 0);
+	//assert((v0 & 0x3) == 0);
+
 	u32 count = ((t9+3) & 0xfffc);
 	//v0 = (v0) & 0xfffc;
 	//v1 = (v1) & 0xfffc;
@@ -920,12 +919,10 @@ void DMEMMOVE () { // Doesn't sound just right?... will fix when HLE is ready - 
 void LOADADPCM () { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
-#ifdef _DEBUG
-	if (v0 > (1024*1024*8))
-		v0 = (t9 & 0xffffff);
-	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
-	assert ((k0&0xffff) <= 0x80);
-#endif
+//	if (v0 > (1024*1024*8))
+//		v0 = (t9 & 0xffffff);
+//	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
+//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram+v0);
 	for (u32 x = 0; x < ((k0&0xffff)>>0x4); x++) {
 		adpcmtable[0x1+(x<<3)] = table[0];

--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -58,9 +58,9 @@ void SETLOOP2 () {
 }
 
 void SETBUFF2 () {
-	AudioInBuffer   = u16(k0);			 // 0x00
-	AudioOutBuffer	= u16((t9 >> 0x10)); // 0x02
-	AudioCount		= u16(t9);			 // 0x04
+	AudioInBuffer   = (u16)(k0);           // 0x00
+	AudioOutBuffer  = (u16)(t9 >> 0x10);   // 0x02
+	AudioCount      = (u16)(t9);           // 0x04
 }
 
 void ADPCM2 () { // Verified to be 100% Accurate...

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -128,9 +128,10 @@ void ENVMIXER3 () {
 		RVol   = *(s32 *)(hleMixerWorkArea + 18); // 18-19
 		LSig   = *(s16 *)(hleMixerWorkArea + 20); // 20-21
 		RSig   = *(s16 *)(hleMixerWorkArea + 22); // 22-23
-		//u32 test  = *(s32 *)(hleMixerWorkArea + 24); // 22-23
-		//if (test != 0x13371337)
-		//	__asm int 3;
+#ifdef _DEBUG
+		u32 test  = *(s32 *)(hleMixerWorkArea + 24); // 22-23
+		assert(test == 0x13371337);
+#endif
 	}
 
 
@@ -515,8 +516,10 @@ void SAVEBUFF3 () {
 void LOADADPCM3 () { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
 	v0 = (t9 & 0xffffff);
-	//memcpy (dmem+0x3f0, rdram+v0, k0&0xffff); 
-	//assert ((k0&0xffff) <= 0x80);
+#ifdef _DEBUG
+	memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
+	assert ((k0&0xffff) <= 0x80);
+#endif
 	u16 *table = (u16 *)(rdram+v0);
 	for (u32 x = 0; x < ((k0&0xffff)>>0x4); x++) {
 		adpcmtable[0x1+(x<<3)] = table[0];
@@ -843,8 +846,9 @@ void RESAMPLE3 () {
 			src[(srcPtr+x)^1] = 0;//*(u16 *)(rdram+((addy+x)^2));
 	}
 
-	//if ((Flags & 0x2))
-	//	__asm int 3;
+#ifdef _DEBUG
+	assert((Flags & 0x2) == 0);
+#endif
 
 	for(int i=0;i < 0x170/2;i++)	{
 		location = (((Accum * 0x40) >> 0x10) * 8);
@@ -974,7 +978,7 @@ void WHATISTHIS () {
 u32 setaddr;
 void MP3ADDY () {
 	setaddr = (t9 & 0xffffff);
-	//__asm int 3;
+	//assert(0);
 	//fprintf (fp, "mp3addy: k0: %08X, t9: %08X, loopval: %08X\n", k0, t9, loopval);
 }
 
@@ -1001,7 +1005,7 @@ void MP3 ();
 	((u32*)BufferSpace)[0x008/4] += base;
 	((u32*)BufferSpace)[0xFFC/4] = loopval;
 	((u32*)BufferSpace)[0xFF8/4] = dmembase;
-	//__asm int 3;
+	//assert(0);
 	memcpy (imem+0x238, rdram+((u32*)BufferSpace)[0x008/4], 0x9C0);
 	((u32*)BufferSpace)[0xFF4/4] = setaddr;
 	pDMEM = (char *)BufferSpace;

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -512,10 +512,8 @@ void SAVEBUFF3 () {
 void LOADADPCM3 () { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
 	v0 = (t9 & 0xffffff);
-#ifdef _DEBUG
-	memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
-	assert ((k0&0xffff) <= 0x80);
-#endif
+	//memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
+	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram+v0);
 	for (u32 x = 0; x < ((k0&0xffff)>>0x4); x++) {
 		adpcmtable[0x1+(x<<3)] = table[0];

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -128,10 +128,6 @@ void ENVMIXER3 () {
 		RVol   = *(s32 *)(hleMixerWorkArea + 18); // 18-19
 		LSig   = *(s16 *)(hleMixerWorkArea + 20); // 20-21
 		RSig   = *(s16 *)(hleMixerWorkArea + 22); // 22-23
-#ifdef _DEBUG
-		u32 test  = *(s32 *)(hleMixerWorkArea + 24); // 22-23
-		assert(test == 0x13371337);
-#endif
 	}
 
 

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -236,7 +236,21 @@ void MP3 () {
 	}
 }
 
-
+void x86_interrupt(void)
+{
+#if defined(_MSC_VER)
+__asm
+	int 3;
+#elif defined(__GNUC__)
+__asm__(
+	".intel_syntax;"
+	"INT     3;"
+);
+#else
+#error Not sure how to do an interrupt on this compiler.
+#endif
+	return;
+}
 
 void InnerLoop () {
 				int x;
@@ -282,7 +296,7 @@ void InnerLoop () {
 				RSP_Vect[0].DW[0] = 0x0002D4130005A827;
 */
 				if ((t1 | t2 | t3 | t5 | t6) & 0x1)
-					__asm int 3;
+					x86_interrupt();
 
 				// 0x13A8
 				v[1] = 0;

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -236,22 +236,6 @@ void MP3 () {
 	}
 }
 
-void x86_interrupt(void)
-{
-#if defined(_MSC_VER)
-__asm
-	int 3;
-#elif defined(__GNUC__)
-__asm__(
-	".intel_syntax;"
-	"INT     3;"
-);
-#else
-#error Not sure how to do an interrupt on this compiler.
-#endif
-	return;
-}
-
 void InnerLoop () {
 				int x;
 				// Part 1: 100% Accurate
@@ -295,8 +279,7 @@ void InnerLoop () {
 				RSP_Vect[0].DW[1] = 0xB504A57E00016A09;
 				RSP_Vect[0].DW[0] = 0x0002D4130005A827;
 */
-				if ((t1 | t2 | t3 | t5 | t6) & 0x1)
-					x86_interrupt();
+				assert(((t1 | t2 | t3 | t5 | t6) & 0x1) == 0);
 
 				// 0x13A8
 				v[1] = 0;

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -363,7 +363,7 @@ void DirectSoundDriver::SetSegmentSize(DWORD length) {
 	dsbdesc.lpwfxFormat = &wfm;
 
 	if (FAILED(hr = IDirectSound_CreateSoundBuffer(lpds, &dsbdesc, &lpdsbuf, NULL))) {
-		__asm int 3;
+		x86_interrupt();
 		return;
 	}
 
@@ -389,7 +389,7 @@ BOOL DirectSoundDriver::Initialize(HWND hwnd) {
 	WaitForSingleObject(hMutex, INFINITE);
 
 	if (FAILED(hr = DirectSoundCreate8(NULL, &lpds, NULL))) {
-		__asm int 3;
+		x86_interrupt();
 		return -1;
 	}
 

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -181,7 +181,7 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 #ifdef STREAM_DMA
 			__try // PJ64 likes to close objects before it shuts down the DLLs completely...
 			{
-				if (play_pos > last_play_pos) bytesMoved = play_pos - last_play_pos; else bytesMoved = TOTAL_SIZE - last_play_pos + play_pos;
+			if (play_pos > last_play_pos) bytesMoved = play_pos - last_play_pos; else bytesMoved = TOTAL_SIZE - last_play_pos + play_pos;
 			last_play_pos = play_pos;
 			if (DMALen[0] != 0 && (*AudioInfo.AI_CONTROL_REG & 0x01) == 1)
 			{

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -179,8 +179,10 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 
 
 #ifdef STREAM_DMA
+#ifdef SEH_SUPPORTED
 			__try // PJ64 likes to close objects before it shuts down the DLLs completely...
 			{
+#endif
 			if (play_pos > last_play_pos) bytesMoved = play_pos - last_play_pos; else bytesMoved = TOTAL_SIZE - last_play_pos + play_pos;
 			last_play_pos = play_pos;
 			if (DMALen[0] != 0 && (*AudioInfo.AI_CONTROL_REG & 0x01) == 1)
@@ -275,10 +277,12 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 			{
 				//if (last_pos == write_pos)	Sleep(1);
 			}
+#ifdef SEH_SUPPORTED
 			}
 			__except (EXCEPTION_EXECUTE_HANDLER)
 			{
 			}
+#endif
 #endif
 		}
 		// This means we had a buffer segment skipped skip

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -362,10 +362,7 @@ void DirectSoundDriver::SetSegmentSize(DWORD length) {
 	dsbdesc.dwBufferBytes = SegmentSize * SEGMENTS;
 	dsbdesc.lpwfxFormat = &wfm;
 
-	if (FAILED(hr = IDirectSound_CreateSoundBuffer(lpds, &dsbdesc, &lpdsbuf, NULL))) {
-		x86_interrupt();
-		return;
-	}
+	assert(!FAILED(hr = IDirectSound_CreateSoundBuffer(lpds, &dsbdesc, &lpdsbuf, NULL)));
 
 	IDirectSoundBuffer_Play(lpdsbuf, 0, 0, DSBPLAY_LOOPING);
 	lpdsbuff = this->lpdsbuf;
@@ -388,10 +385,7 @@ BOOL DirectSoundDriver::Initialize(HWND hwnd) {
 
 	WaitForSingleObject(hMutex, INFINITE);
 
-	if (FAILED(hr = DirectSoundCreate8(NULL, &lpds, NULL))) {
-		x86_interrupt();
-		return -1;
-	}
+	assert(!FAILED(hr = DirectSoundCreate8(NULL, &lpds, NULL)));
 
 	if (FAILED(hr = IDirectSound_SetCooperativeLevel(lpds, hwnd, DSSCL_PRIORITY))) {
 		return -1;

--- a/AziAudio/Mupen64plusHLE/Mupen64Support.c
+++ b/AziAudio/Mupen64plusHLE/Mupen64Support.c
@@ -4,6 +4,10 @@
 #include "hle_internal.h"
 #include "../AudioSpec.h"
 
+#ifndef UNUSED
+#define UNUSED(name)    name
+#endif
+
 void HleWarnMessage(void* UNUSED(user_defined), const char *message, ...)
 {
 	va_list args;

--- a/AziAudio/Mupen64plusHLE/Mupen64Support.c
+++ b/AziAudio/Mupen64plusHLE/Mupen64Support.c
@@ -1,12 +1,11 @@
 #include <stdarg.h>
 #include <stdio.h>
+
+#include "common.h"
+
 #include "hle_external.h"
 #include "hle_internal.h"
 #include "../AudioSpec.h"
-
-#ifndef UNUSED
-#define UNUSED(name)    name
-#endif
 
 void HleWarnMessage(void* UNUSED(user_defined), const char *message, ...)
 {

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -59,8 +59,13 @@ protected:
 		configHLE = true;
 		configRSP = true;
 		configVolume = 0;
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 		strcpy_s(configAudioLogFolder, 500, "D:\\");
 		strcpy_s(configDevice, 100, "");
+#else
+		strcpy(configAudioLogFolder, "D:\\");
+		strcpy(configDevice, "");
+#endif
 	}
 };
 

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -80,9 +80,3 @@ extern u32 t0, t1, t2, t3, t4, t5, t6, t7;
 extern u32 s0, s1, s2, s3, s4, s5, s6, s7;
 extern u32 t8, t9, k0, k1, gp, sp, s8, ra;
 */
-
-/*
- * in-line assembly that should execute `INT 3;`
- * Currently it should compile in MSVC or MinGW/GCC.
- */
-extern void x86_interrupt(void);

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -80,3 +80,9 @@ extern u32 t0, t1, t2, t3, t4, t5, t6, t7;
 extern u32 s0, s1, s2, s3, s4, s5, s6, s7;
 extern u32 t8, t9, k0, k1, gp, sp, s8, ra;
 */
+
+/*
+ * in-line assembly that should execute `INT 3;`
+ * Currently it should compile in MSVC or MinGW/GCC.
+ */
+extern void x86_interrupt(void);

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -108,3 +108,9 @@ unsigned long GenerateCRC (unsigned char *data, int size);
  * Currently it should compile in MSVC or MinGW/GCC.
  */
 extern void x86_interrupt(void);
+
+/*
+ * `strcpy` with bounds checking
+ * This basically is a portable variation of Microsoft's `strcpy_s`.
+ */
+extern int safe_strcpy(char* dst, size_t limit, const char* src);

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -16,6 +16,10 @@
 
 //#define ENABLEPROFILING
 
+#if defined(_MSC_VER)
+#define SEH_SUPPORTED
+#endif
+
 #define USE_XAUDIO2
 
 #include "mytypes.h"

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -102,3 +102,9 @@ unsigned long GenerateCRC (unsigned char *data, int size);
 #	define PrintProfiles() //
 #	define ClearProfiles()//
 #endif
+
+/*
+ * in-line assembly that should execute `INT 3;`
+ * Currently it should compile in MSVC or MinGW/GCC.
+ */
+extern void x86_interrupt(void);

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -20,7 +20,9 @@
 #define SEH_SUPPORTED
 #endif
 
+#ifndef XAUDIO_LIBRARIES_UNAVAILABLE
 #define USE_XAUDIO2
+#endif
 
 #include "mytypes.h"
 

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -14,6 +14,8 @@
 #include <windows.h>
 #include <stdio.h>
 
+#include <assert.h>
+
 //#define ENABLEPROFILING
 
 #if defined(_MSC_VER)
@@ -104,12 +106,6 @@ unsigned long GenerateCRC (unsigned char *data, int size);
 #	define PrintProfiles() //
 #	define ClearProfiles()//
 #endif
-
-/*
- * in-line assembly that should execute `INT 3;`
- * Currently it should compile in MSVC or MinGW/GCC.
- */
-extern void x86_interrupt(void);
 
 /*
  * `strcpy` with bounds checking

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -77,7 +77,7 @@ BOOL WINAPI DllMain(
 BOOL CALLBACK DSEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrvName, LPVOID lpContext )
 {
 	HWND hDlg = (HWND)lpContext;
-	strcpy_s(DSoundDeviceName[DSoundCnt], 99, lpszDesc);
+	safe_strcpy(DSoundDeviceName[DSoundCnt], 99, lpszDesc);
 	DSoundGUID[DSoundCnt] = lpGUID;
 	if (strcmp(lpszDesc, snd.configDevice) == 0)
 	{
@@ -129,7 +129,7 @@ BOOL CALLBACK ConfigProc(
 					snd.configHLE = SendMessage(GetDlgItem(hDlg,IDC_HLE      ),BM_GETSTATE, 0,0) == BST_CHECKED?true:false;
 					snd.configRSP = SendMessage(GetDlgItem(hDlg,IDC_RSP      ),BM_GETSTATE, 0,0) == BST_CHECKED?true:false;
 					SelectedDSound = SendMessage(GetDlgItem(hDlg, IDC_DEVICE), CB_GETCURSEL, 0, 0);
-					strcpy_s(snd.configDevice, 99, DSoundDeviceName[SelectedDSound]);
+					safe_strcpy(snd.configDevice, 99, DSoundDeviceName[SelectedDSound]);
 					EndDialog(hDlg, 0);
 				break;
 				case IDCANCEL:
@@ -215,7 +215,7 @@ EXPORT BOOL CALL InitiateAudio (AUDIO_INFO Audio_Info){
 	snd.configMute		  = false;
 	snd.configHLE		  = true;
 	snd.configRSP		  = true;
-	strcpy_s (snd.configAudioLogFolder, 499, "D:\\");
+	safe_strcpy(snd.configAudioLogFolder, 499, "D:\\");
 
 	//snd.configDevice = 0;
 	snd.configVolume = 0;
@@ -255,7 +255,7 @@ EXPORT void CALL CloseDLL (void){
 EXPORT void CALL GetDllInfo ( PLUGIN_INFO * PluginInfo ){
 	PluginInfo->MemoryBswaped = TRUE;
 	PluginInfo->NormalMemory  = FALSE;
-	strcpy_s (PluginInfo->Name, PLUGIN_VERSION);
+	safe_strcpy(PluginInfo->Name, 100, PLUGIN_VERSION);
 	PluginInfo->Type = PLUGIN_TYPE_AUDIO;
 	PluginInfo->Version = 0x0101; // Set this to retain backwards compatibility
 }
@@ -417,4 +417,28 @@ void RedirectIOToConsole() {
 	// make cout, wcout, cin, wcin, wcerr, cerr, wclog and clog 
 	// point to console as well
 	ios::sync_with_stdio();
+}
+
+int safe_strcpy(char* dst, size_t limit, const char* src)
+{
+#if defined(_MSC_VER)
+    return strcpy_s(dst, limit, src);
+#else
+    size_t bytes;
+    int failure;
+
+    if (dst == NULL || src == NULL)
+        return (failure = 22); /* EINVAL, from MSVC <errno.h> */
+
+    bytes = strlen(src) + 1; /* strlen("abc") + 1 == 4 bytes */
+    failure = 34; /* ERANGE, from MSVC <errno.h> */
+    if (bytes > limit)
+        bytes = limit;
+    else
+        failure = 0;
+
+    memcpy(dst, src, bytes);
+    dst[limit - 1] = '\0'; /* in case of ERANGE, may not be null-terminated */
+    return (failure);
+#endif
 }

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -30,8 +30,11 @@
 
 using namespace std;
 
-//DirectSoundDriver snd;// = AudioCode();
+#if defined(XAUDIO_LIBRARIES_UNAVAILABLE) && !defined(USE_XAUDIO2)
+DirectSoundDriver snd;// = AudioCode();
+#else
 XAudio2SoundDriver snd;// = AudioCode();
+#endif
 
 // Direct Sound selection
 char DSoundDeviceName[10][100];

--- a/AziAudio/mytypes.h
+++ b/AziAudio/mytypes.h
@@ -12,14 +12,15 @@
 #ifndef __MYTYPES_DOT_H__
 #define __MYTYPES_DOT_H__
 
-typedef unsigned char           u8;
-typedef signed char             s8;
-typedef unsigned short          u16;
-typedef signed short            s16;
-typedef unsigned long           u32;
-typedef signed long             s32;
+#define u8	unsigned char
+#define s8	signed char
+#define u16	unsigned short
+#define s16	signed short
+#define u32	unsigned long
+#define s32	signed long
 #define u64	unsigned __int64
 #define s64	signed __int64
+
 /*
 #ifndef WIN32
 #define BYTE   unsigned char

--- a/AziAudio/mytypes.h
+++ b/AziAudio/mytypes.h
@@ -14,7 +14,7 @@
 
 #define	u8	unsigned char
 #define s8	signed char
-#define u16	unsigned short
+typedef unsigned short          u16;
 #define s16	signed short
 #define u32	unsigned long
 #define s32	signed long

--- a/AziAudio/mytypes.h
+++ b/AziAudio/mytypes.h
@@ -12,12 +12,12 @@
 #ifndef __MYTYPES_DOT_H__
 #define __MYTYPES_DOT_H__
 
-#define	u8	unsigned char
-#define s8	signed char
+typedef unsigned char           u8;
+typedef signed char             s8;
 typedef unsigned short          u16;
-#define s16	signed short
-#define u32	unsigned long
-#define s32	signed long
+typedef signed short            s16;
+typedef unsigned long           u32;
+typedef signed long             s32;
 #define u64	unsigned __int64
 #define s64	signed __int64
 /*

--- a/gccbuild/dx_mingw/dsound.h
+++ b/gccbuild/dx_mingw/dsound.h
@@ -1,0 +1,2345 @@
+/*==========================================================================;
+ *
+ *  Copyright (C) 1995-2000 Microsoft Corporation.  All Rights Reserved.
+ *
+ *  File:       dsound.h
+ *  Content:    DirectSound include file
+ *
+ **************************************************************************/
+
+#define COM_NO_WINDOWS_H
+#include <objbase.h>
+#include <float.h>
+
+#ifndef DIRECTSOUND_VERSION
+#define DIRECTSOUND_VERSION 0x0800  /* Version 8.0 */
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifndef __DSOUND_INCLUDED__
+#define __DSOUND_INCLUDED__
+
+/* Type definitions shared with Direct3D */
+
+#ifndef DX_SHARED_DEFINES
+
+typedef float D3DVALUE, *LPD3DVALUE;
+
+#ifndef D3DCOLOR_DEFINED
+typedef DWORD D3DCOLOR;
+#define D3DCOLOR_DEFINED
+#endif
+
+#ifndef LPD3DCOLOR_DEFINED
+typedef DWORD *LPD3DCOLOR;
+#define LPD3DCOLOR_DEFINED
+#endif
+
+#ifndef D3DVECTOR_DEFINED
+typedef struct _D3DVECTOR {
+    float x;
+    float y;
+    float z;
+} D3DVECTOR;
+#define D3DVECTOR_DEFINED
+#endif
+
+#ifndef LPD3DVECTOR_DEFINED
+typedef D3DVECTOR *LPD3DVECTOR;
+#define LPD3DVECTOR_DEFINED
+#endif
+
+#define DX_SHARED_DEFINES
+#endif // DX_SHARED_DEFINES
+
+#define _FACDS  0x878   /* DirectSound's facility code */
+#define MAKE_DSHRESULT(code)  MAKE_HRESULT(1, _FACDS, code)
+
+// DirectSound Component GUID {47D4D946-62E8-11CF-93BC-444553540000}
+DEFINE_GUID(CLSID_DirectSound, 0x47d4d946, 0x62e8, 0x11cf, 0x93, 0xbc, 0x44, 0x45, 0x53, 0x54, 0x0, 0x0);
+
+// DirectSound 8.0 Component GUID {3901CC3F-84B5-4FA4-BA35-AA8172B8A09B}
+DEFINE_GUID(CLSID_DirectSound8, 0x3901cc3f, 0x84b5, 0x4fa4, 0xba, 0x35, 0xaa, 0x81, 0x72, 0xb8, 0xa0, 0x9b);
+
+// DirectSound Capture Component GUID {B0210780-89CD-11D0-AF08-00A0C925CD16}
+DEFINE_GUID(CLSID_DirectSoundCapture, 0xb0210780, 0x89cd, 0x11d0, 0xaf, 0x8, 0x0, 0xa0, 0xc9, 0x25, 0xcd, 0x16);
+
+// DirectSound 8.0 Capture Component GUID {E4BCAC13-7F99-4908-9A8E-74E3BF24B6E1}
+DEFINE_GUID(CLSID_DirectSoundCapture8, 0xe4bcac13, 0x7f99, 0x4908, 0x9a, 0x8e, 0x74, 0xe3, 0xbf, 0x24, 0xb6, 0xe1);
+
+// DirectSound Full Duplex Component GUID {FEA4300C-7959-4147-B26A-2377B9E7A91D}
+DEFINE_GUID(CLSID_DirectSoundFullDuplex, 0xfea4300c, 0x7959, 0x4147, 0xb2, 0x6a, 0x23, 0x77, 0xb9, 0xe7, 0xa9, 0x1d);
+
+
+// DirectSound default playback device GUID {DEF00000-9C6D-47ED-AAF1-4DDA8F2B5C03}
+DEFINE_GUID(DSDEVID_DefaultPlayback, 0xdef00000, 0x9c6d, 0x47ed, 0xaa, 0xf1, 0x4d, 0xda, 0x8f, 0x2b, 0x5c, 0x03);
+
+// DirectSound default capture device GUID {DEF00001-9C6D-47ED-AAF1-4DDA8F2B5C03}
+DEFINE_GUID(DSDEVID_DefaultCapture, 0xdef00001, 0x9c6d, 0x47ed, 0xaa, 0xf1, 0x4d, 0xda, 0x8f, 0x2b, 0x5c, 0x03);
+
+// DirectSound default device for voice playback {DEF00002-9C6D-47ED-AAF1-4DDA8F2B5C03}
+DEFINE_GUID(DSDEVID_DefaultVoicePlayback, 0xdef00002, 0x9c6d, 0x47ed, 0xaa, 0xf1, 0x4d, 0xda, 0x8f, 0x2b, 0x5c, 0x03);
+
+// DirectSound default device for voice capture {DEF00003-9C6D-47ED-AAF1-4DDA8F2B5C03}
+DEFINE_GUID(DSDEVID_DefaultVoiceCapture, 0xdef00003, 0x9c6d, 0x47ed, 0xaa, 0xf1, 0x4d, 0xda, 0x8f, 0x2b, 0x5c, 0x03);
+
+
+//
+// Forward declarations for interfaces.
+// 'struct' not 'class' per the way DECLARE_INTERFACE_ is defined
+//
+
+#ifdef __cplusplus
+struct IDirectSound;
+struct IDirectSoundBuffer;
+struct IDirectSound3DListener;
+struct IDirectSound3DBuffer;
+struct IDirectSoundCapture;
+struct IDirectSoundCaptureBuffer;
+struct IDirectSoundNotify;
+#endif // __cplusplus
+
+
+//
+// DirectSound 8.0 interfaces.
+//
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+#ifdef __cplusplus
+struct IDirectSound8;
+struct IDirectSoundBuffer8;
+struct IDirectSoundCaptureBuffer8;
+struct IDirectSoundFXGargle;
+struct IDirectSoundFXChorus;
+struct IDirectSoundFXFlanger;
+struct IDirectSoundFXEcho;
+struct IDirectSoundFXDistortion;
+struct IDirectSoundFXCompressor;
+struct IDirectSoundFXParamEq;
+struct IDirectSoundFXWavesReverb;
+struct IDirectSoundFXI3DL2Reverb;
+struct IDirectSoundCaptureFXAec;
+struct IDirectSoundCaptureFXNoiseSuppress;
+struct IDirectSoundFullDuplex;
+#endif // __cplusplus
+
+// IDirectSound8, IDirectSoundBuffer8 and IDirectSoundCaptureBuffer8 are the
+// only DirectSound 7.0 interfaces with changed functionality in version 8.0.
+// The other level 8 interfaces as equivalent to their level 7 counterparts:
+
+#define IDirectSoundCapture8            IDirectSoundCapture
+#define IDirectSound3DListener8         IDirectSound3DListener
+#define IDirectSound3DBuffer8           IDirectSound3DBuffer
+#define IDirectSoundNotify8             IDirectSoundNotify
+#define IDirectSoundFXGargle8           IDirectSoundFXGargle
+#define IDirectSoundFXChorus8           IDirectSoundFXChorus
+#define IDirectSoundFXFlanger8          IDirectSoundFXFlanger
+#define IDirectSoundFXEcho8             IDirectSoundFXEcho
+#define IDirectSoundFXDistortion8       IDirectSoundFXDistortion
+#define IDirectSoundFXCompressor8       IDirectSoundFXCompressor
+#define IDirectSoundFXParamEq8          IDirectSoundFXParamEq
+#define IDirectSoundFXWavesReverb8      IDirectSoundFXWavesReverb
+#define IDirectSoundFXI3DL2Reverb8      IDirectSoundFXI3DL2Reverb
+#define IDirectSoundCaptureFXAec8       IDirectSoundCaptureFXAec
+#define IDirectSoundCaptureFXNoiseSuppress8 IDirectSoundCaptureFXNoiseSuppress
+#define IDirectSoundFullDuplex8         IDirectSoundFullDuplex
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+
+typedef struct IDirectSound                 *LPDIRECTSOUND;
+typedef struct IDirectSoundBuffer           *LPDIRECTSOUNDBUFFER;
+typedef struct IDirectSound3DListener       *LPDIRECTSOUND3DLISTENER;
+typedef struct IDirectSound3DBuffer         *LPDIRECTSOUND3DBUFFER;
+typedef struct IDirectSoundCapture          *LPDIRECTSOUNDCAPTURE;
+typedef struct IDirectSoundCaptureBuffer    *LPDIRECTSOUNDCAPTUREBUFFER;
+typedef struct IDirectSoundNotify           *LPDIRECTSOUNDNOTIFY;
+
+
+#if DIRECTSOUND_VERSION >= 0x0800
+typedef struct IDirectSoundFXGargle         *LPDIRECTSOUNDFXGARGLE;
+typedef struct IDirectSoundFXChorus         *LPDIRECTSOUNDFXCHORUS;
+typedef struct IDirectSoundFXFlanger        *LPDIRECTSOUNDFXFLANGER;
+typedef struct IDirectSoundFXEcho           *LPDIRECTSOUNDFXECHO;
+typedef struct IDirectSoundFXDistortion     *LPDIRECTSOUNDFXDISTORTION;
+typedef struct IDirectSoundFXCompressor     *LPDIRECTSOUNDFXCOMPRESSOR;
+typedef struct IDirectSoundFXParamEq        *LPDIRECTSOUNDFXPARAMEQ;
+typedef struct IDirectSoundFXWavesReverb    *LPDIRECTSOUNDFXWAVESREVERB;
+typedef struct IDirectSoundFXI3DL2Reverb    *LPDIRECTSOUNDFXI3DL2REVERB;
+typedef struct IDirectSoundCaptureFXAec     *LPDIRECTSOUNDCAPTUREFXAEC;
+typedef struct IDirectSoundCaptureFXNoiseSuppress *LPDIRECTSOUNDCAPTUREFXNOISESUPPRESS;
+typedef struct IDirectSoundFullDuplex       *LPDIRECTSOUNDFULLDUPLEX;
+
+typedef struct IDirectSound8                *LPDIRECTSOUND8;
+typedef struct IDirectSoundBuffer8          *LPDIRECTSOUNDBUFFER8;
+typedef struct IDirectSound3DListener8      *LPDIRECTSOUND3DLISTENER8;
+typedef struct IDirectSound3DBuffer8        *LPDIRECTSOUND3DBUFFER8;
+typedef struct IDirectSoundCapture8         *LPDIRECTSOUNDCAPTURE8;
+typedef struct IDirectSoundCaptureBuffer8   *LPDIRECTSOUNDCAPTUREBUFFER8;
+typedef struct IDirectSoundNotify8          *LPDIRECTSOUNDNOTIFY8;
+typedef struct IDirectSoundFXGargle8        *LPDIRECTSOUNDFXGARGLE8;
+typedef struct IDirectSoundFXChorus8        *LPDIRECTSOUNDFXCHORUS8;
+typedef struct IDirectSoundFXFlanger8       *LPDIRECTSOUNDFXFLANGER8;
+typedef struct IDirectSoundFXEcho8          *LPDIRECTSOUNDFXECHO8;
+typedef struct IDirectSoundFXDistortion8    *LPDIRECTSOUNDFXDISTORTION8;
+typedef struct IDirectSoundFXCompressor8    *LPDIRECTSOUNDFXCOMPRESSOR8;
+typedef struct IDirectSoundFXParamEq8       *LPDIRECTSOUNDFXPARAMEQ8;
+typedef struct IDirectSoundFXWavesReverb8   *LPDIRECTSOUNDFXWAVESREVERB8;
+typedef struct IDirectSoundFXI3DL2Reverb8   *LPDIRECTSOUNDFXI3DL2REVERB8;
+typedef struct IDirectSoundCaptureFXAec8    *LPDIRECTSOUNDCAPTUREFXAEC8;
+typedef struct IDirectSoundCaptureFXNoiseSuppress8 *LPDIRECTSOUNDCAPTUREFXNOISESUPPRESS8;
+typedef struct IDirectSoundFullDuplex8      *LPDIRECTSOUNDFULLDUPLEX8;
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IID definitions for the unchanged DirectSound 8.0 interfaces
+//
+
+#if DIRECTSOUND_VERSION >= 0x0800
+#define IID_IDirectSoundCapture8            IID_IDirectSoundCapture
+#define IID_IDirectSound3DListener8         IID_IDirectSound3DListener
+#define IID_IDirectSound3DBuffer8           IID_IDirectSound3DBuffer
+#define IID_IDirectSoundNotify8             IID_IDirectSoundNotify
+#define IID_IDirectSoundFXGargle8           IID_IDirectSoundFXGargle
+#define IID_IDirectSoundFXChorus8           IID_IDirectSoundFXChorus
+#define IID_IDirectSoundFXFlanger8          IID_IDirectSoundFXFlanger
+#define IID_IDirectSoundFXEcho8             IID_IDirectSoundFXEcho
+#define IID_IDirectSoundFXDistortion8       IID_IDirectSoundFXDistortion
+#define IID_IDirectSoundFXCompressor8       IID_IDirectSoundFXCompressor
+#define IID_IDirectSoundFXParamEq8          IID_IDirectSoundFXParamEq
+#define IID_IDirectSoundFXWavesReverb8      IID_IDirectSoundFXWavesReverb
+#define IID_IDirectSoundFXI3DL2Reverb8      IID_IDirectSoundFXI3DL2Reverb
+#define IID_IDirectSoundCaptureFXAec8       IID_IDirectSoundCaptureFXAec
+#define IID_IDirectSoundCaptureFXNoiseSuppress8 IID_IDirectSoundCaptureFXNoiseSuppress
+#define IID_IDirectSoundFullDuplex8         IID_IDirectSoundFullDuplex
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// Compatibility typedefs
+//
+
+#ifndef _LPCWAVEFORMATEX_DEFINED
+#define _LPCWAVEFORMATEX_DEFINED
+typedef const WAVEFORMATEX *LPCWAVEFORMATEX;
+#endif // _LPCWAVEFORMATEX_DEFINED
+
+#ifndef __LPCGUID_DEFINED__
+#define __LPCGUID_DEFINED__
+typedef const GUID *LPCGUID;
+#endif // __LPCGUID_DEFINED__
+
+typedef LPDIRECTSOUND *LPLPDIRECTSOUND;
+typedef LPDIRECTSOUNDBUFFER *LPLPDIRECTSOUNDBUFFER;
+typedef LPDIRECTSOUND3DLISTENER *LPLPDIRECTSOUND3DLISTENER;
+typedef LPDIRECTSOUND3DBUFFER *LPLPDIRECTSOUND3DBUFFER;
+typedef LPDIRECTSOUNDCAPTURE *LPLPDIRECTSOUNDCAPTURE;
+typedef LPDIRECTSOUNDCAPTUREBUFFER *LPLPDIRECTSOUNDCAPTUREBUFFER;
+typedef LPDIRECTSOUNDNOTIFY *LPLPDIRECTSOUNDNOTIFY;
+
+#if DIRECTSOUND_VERSION >= 0x0800
+typedef LPDIRECTSOUND8 *LPLPDIRECTSOUND8;
+typedef LPDIRECTSOUNDBUFFER8 *LPLPDIRECTSOUNDBUFFER8;
+typedef LPDIRECTSOUNDCAPTURE8 *LPLPDIRECTSOUNDCAPTURE8;
+typedef LPDIRECTSOUNDCAPTUREBUFFER8 *LPLPDIRECTSOUNDCAPTUREBUFFER8;
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// Structures
+//
+
+typedef struct _DSCAPS
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwMinSecondarySampleRate;
+    DWORD           dwMaxSecondarySampleRate;
+    DWORD           dwPrimaryBuffers;
+    DWORD           dwMaxHwMixingAllBuffers;
+    DWORD           dwMaxHwMixingStaticBuffers;
+    DWORD           dwMaxHwMixingStreamingBuffers;
+    DWORD           dwFreeHwMixingAllBuffers;
+    DWORD           dwFreeHwMixingStaticBuffers;
+    DWORD           dwFreeHwMixingStreamingBuffers;
+    DWORD           dwMaxHw3DAllBuffers;
+    DWORD           dwMaxHw3DStaticBuffers;
+    DWORD           dwMaxHw3DStreamingBuffers;
+    DWORD           dwFreeHw3DAllBuffers;
+    DWORD           dwFreeHw3DStaticBuffers;
+    DWORD           dwFreeHw3DStreamingBuffers;
+    DWORD           dwTotalHwMemBytes;
+    DWORD           dwFreeHwMemBytes;
+    DWORD           dwMaxContigFreeHwMemBytes;
+    DWORD           dwUnlockTransferRateHwBuffers;
+    DWORD           dwPlayCpuOverheadSwBuffers;
+    DWORD           dwReserved1;
+    DWORD           dwReserved2;
+} DSCAPS, *LPDSCAPS;
+
+typedef const DSCAPS *LPCDSCAPS;
+
+typedef struct _DSBCAPS
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwUnlockTransferRate;
+    DWORD           dwPlayCpuOverhead;
+} DSBCAPS, *LPDSBCAPS;
+
+typedef const DSBCAPS *LPCDSBCAPS;
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+    typedef struct _DSEFFECTDESC
+    {
+        DWORD       dwSize;
+        DWORD       dwFlags;
+        GUID        guidDSFXClass;
+        DWORD       dwReserved1;
+        DWORD       dwReserved2;
+    } DSEFFECTDESC, *LPDSEFFECTDESC;
+    typedef const DSEFFECTDESC *LPCDSEFFECTDESC;
+
+    #define DSFX_LOCHARDWARE    0x00000001
+    #define DSFX_LOCSOFTWARE    0x00000002
+
+    enum
+    {
+        DSFXR_PRESENT,          // 0
+        DSFXR_LOCHARDWARE,      // 1
+        DSFXR_LOCSOFTWARE,      // 2
+        DSFXR_UNALLOCATED,      // 3
+        DSFXR_FAILED,           // 4
+        DSFXR_UNKNOWN,          // 5
+        DSFXR_SENDLOOP          // 6
+    };
+
+    typedef struct _DSCEFFECTDESC
+    {
+        DWORD       dwSize;
+        DWORD       dwFlags;
+        GUID        guidDSCFXClass;
+        GUID        guidDSCFXInstance;
+        DWORD       dwReserved1;
+        DWORD       dwReserved2;
+    } DSCEFFECTDESC, *LPDSCEFFECTDESC;
+    typedef const DSCEFFECTDESC *LPCDSCEFFECTDESC;
+
+    #define DSCFX_LOCHARDWARE   0x00000001
+    #define DSCFX_LOCSOFTWARE   0x00000002
+
+    #define DSCFXR_LOCHARDWARE  0x00000010
+    #define DSCFXR_LOCSOFTWARE  0x00000020
+    #define DSCFXR_UNALLOCATED  0x00000040
+    #define DSCFXR_FAILED       0x00000080
+    #define DSCFXR_UNKNOWN      0x00000100
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+typedef struct _DSBUFFERDESC
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwReserved;
+    LPWAVEFORMATEX  lpwfxFormat;
+#if DIRECTSOUND_VERSION >= 0x0700
+    GUID            guid3DAlgorithm;
+#endif
+} DSBUFFERDESC, *LPDSBUFFERDESC;
+
+typedef const DSBUFFERDESC *LPCDSBUFFERDESC;
+
+// Older version of this structure:
+
+typedef struct _DSBUFFERDESC1
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwReserved;
+    LPWAVEFORMATEX  lpwfxFormat;
+} DSBUFFERDESC1, *LPDSBUFFERDESC1;
+
+typedef const DSBUFFERDESC1 *LPCDSBUFFERDESC1;
+
+typedef struct _DS3DBUFFER
+{
+    DWORD           dwSize;
+    D3DVECTOR       vPosition;
+    D3DVECTOR       vVelocity;
+    DWORD           dwInsideConeAngle;
+    DWORD           dwOutsideConeAngle;
+    D3DVECTOR       vConeOrientation;
+    LONG            lConeOutsideVolume;
+    D3DVALUE        flMinDistance;
+    D3DVALUE        flMaxDistance;
+    DWORD           dwMode;
+} DS3DBUFFER, *LPDS3DBUFFER;
+
+typedef const DS3DBUFFER *LPCDS3DBUFFER;
+
+typedef struct _DS3DLISTENER
+{
+    DWORD           dwSize;
+    D3DVECTOR       vPosition;
+    D3DVECTOR       vVelocity;
+    D3DVECTOR       vOrientFront;
+    D3DVECTOR       vOrientTop;
+    D3DVALUE        flDistanceFactor;
+    D3DVALUE        flRolloffFactor;
+    D3DVALUE        flDopplerFactor;
+} DS3DLISTENER, *LPDS3DLISTENER;
+
+typedef const DS3DLISTENER *LPCDS3DLISTENER;
+
+typedef struct _DSCCAPS
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwFormats;
+    DWORD           dwChannels;
+} DSCCAPS, *LPDSCCAPS;
+
+typedef const DSCCAPS *LPCDSCCAPS;
+
+typedef struct _DSCBUFFERDESC1
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwReserved;
+    LPWAVEFORMATEX  lpwfxFormat;
+} DSCBUFFERDESC1, *LPDSCBUFFERDESC1;
+
+typedef struct _DSCBUFFERDESC
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwReserved;
+    LPWAVEFORMATEX  lpwfxFormat;
+#if DIRECTSOUND_VERSION >= 0x0800
+    DWORD           dwFXCount;
+    LPDSCEFFECTDESC lpDSCFXDesc;
+#endif
+} DSCBUFFERDESC, *LPDSCBUFFERDESC;
+
+typedef const DSCBUFFERDESC *LPCDSCBUFFERDESC;
+
+typedef struct _DSCBCAPS
+{
+    DWORD           dwSize;
+    DWORD           dwFlags;
+    DWORD           dwBufferBytes;
+    DWORD           dwReserved;
+} DSCBCAPS, *LPDSCBCAPS;
+
+typedef const DSCBCAPS *LPCDSCBCAPS;
+
+typedef struct _DSBPOSITIONNOTIFY
+{
+    DWORD           dwOffset;
+    HANDLE          hEventNotify;
+} DSBPOSITIONNOTIFY, *LPDSBPOSITIONNOTIFY;
+
+typedef const DSBPOSITIONNOTIFY *LPCDSBPOSITIONNOTIFY;
+
+//
+// DirectSound API
+//
+
+typedef BOOL (CALLBACK *LPDSENUMCALLBACKA)(LPGUID, LPCSTR, LPCSTR, LPVOID);
+typedef BOOL (CALLBACK *LPDSENUMCALLBACKW)(LPGUID, LPCWSTR, LPCWSTR, LPVOID);
+
+extern HRESULT WINAPI DirectSoundCreate(LPCGUID pcGuidDevice, LPDIRECTSOUND *ppDS, LPUNKNOWN pUnkOuter);
+extern HRESULT WINAPI DirectSoundEnumerateA(LPDSENUMCALLBACKA pDSEnumCallback, LPVOID pContext);
+extern HRESULT WINAPI DirectSoundEnumerateW(LPDSENUMCALLBACKW pDSEnumCallback, LPVOID pContext);
+
+extern HRESULT WINAPI DirectSoundCaptureCreate(LPCGUID pcGuidDevice, LPDIRECTSOUNDCAPTURE *ppDSC, LPUNKNOWN pUnkOuter);
+extern HRESULT WINAPI DirectSoundCaptureEnumerateA(LPDSENUMCALLBACKA pDSEnumCallback, LPVOID pContext);
+extern HRESULT WINAPI DirectSoundCaptureEnumerateW(LPDSENUMCALLBACKW pDSEnumCallback, LPVOID pContext);
+
+#if DIRECTSOUND_VERSION >= 0x0800
+extern HRESULT WINAPI DirectSoundCreate8(LPCGUID pcGuidDevice, LPDIRECTSOUND8 *ppDS8, LPUNKNOWN pUnkOuter);
+extern HRESULT WINAPI DirectSoundCaptureCreate8(LPCGUID pcGuidDevice, LPDIRECTSOUNDCAPTURE8 *ppDSC8, LPUNKNOWN pUnkOuter);
+extern HRESULT WINAPI DirectSoundFullDuplexCreate(LPCGUID pcGuidCaptureDevice, LPCGUID pcGuidRenderDevice,
+        LPCDSCBUFFERDESC pcDSCBufferDesc, LPCDSBUFFERDESC pcDSBufferDesc, HWND hWnd,
+        DWORD dwLevel, LPDIRECTSOUNDFULLDUPLEX* ppDSFD, LPDIRECTSOUNDCAPTUREBUFFER8 *ppDSCBuffer8,
+        LPDIRECTSOUNDBUFFER8 *ppDSBuffer8, LPUNKNOWN pUnkOuter);
+#define DirectSoundFullDuplexCreate8 DirectSoundFullDuplexCreate
+
+extern HRESULT WINAPI GetDeviceID(LPCGUID pGuidSrc, LPGUID pGuidDest);
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+#ifdef UNICODE
+#define LPDSENUMCALLBACK            LPDSENUMCALLBACKW
+#define DirectSoundEnumerate        DirectSoundEnumerateW
+#define DirectSoundCaptureEnumerate DirectSoundCaptureEnumerateW
+#else // UNICODE
+#define LPDSENUMCALLBACK            LPDSENUMCALLBACKA
+#define DirectSoundEnumerate        DirectSoundEnumerateA
+#define DirectSoundCaptureEnumerate DirectSoundCaptureEnumerateA
+#endif // UNICODE
+
+//
+// IUnknown
+//
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#ifndef IUnknown_QueryInterface
+#define IUnknown_QueryInterface(p,a,b)  (p)->lpVtbl->QueryInterface(p,a,b)
+#endif // IUnknown_QueryInterface
+#ifndef IUnknown_AddRef
+#define IUnknown_AddRef(p)              (p)->lpVtbl->AddRef(p)
+#endif // IUnknown_AddRef
+#ifndef IUnknown_Release
+#define IUnknown_Release(p)             (p)->lpVtbl->Release(p)
+#endif // IUnknown_Release
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#ifndef IUnknown_QueryInterface
+#define IUnknown_QueryInterface(p,a,b)  (p)->QueryInterface(a,b)
+#endif // IUnknown_QueryInterface
+#ifndef IUnknown_AddRef
+#define IUnknown_AddRef(p)              (p)->AddRef()
+#endif // IUnknown_AddRef
+#ifndef IUnknown_Release
+#define IUnknown_Release(p)             (p)->Release()
+#endif // IUnknown_Release
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#ifndef __IReferenceClock_INTERFACE_DEFINED__
+#define __IReferenceClock_INTERFACE_DEFINED__
+
+typedef LONGLONG REFERENCE_TIME;
+typedef REFERENCE_TIME *LPREFERENCE_TIME;
+
+DEFINE_GUID(IID_IReferenceClock, 0x56a86897, 0x0ad4, 0x11ce, 0xb0, 0x3a, 0x00, 0x20, 0xaf, 0x0b, 0xa7, 0x70);
+
+#undef INTERFACE
+#define INTERFACE IReferenceClock
+
+DECLARE_INTERFACE_(IReferenceClock, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IReferenceClock methods
+    STDMETHOD(GetTime)              (THIS_ REFERENCE_TIME *pTime) PURE;
+    STDMETHOD(AdviseTime)           (THIS_ REFERENCE_TIME rtBaseTime, REFERENCE_TIME rtStreamTime,
+                                           HANDLE hEvent, LPDWORD pdwAdviseCookie) PURE;
+    STDMETHOD(AdvisePeriodic)       (THIS_ REFERENCE_TIME rtStartTime, REFERENCE_TIME rtPeriodTime,
+                                           HANDLE hSemaphore, LPDWORD pdwAdviseCookie) PURE;
+    STDMETHOD(Unadvise)             (THIS_ DWORD dwAdviseCookie) PURE;
+};
+
+#endif // __IReferenceClock_INTERFACE_DEFINED__
+
+#ifndef IReferenceClock_QueryInterface
+
+#define IReferenceClock_QueryInterface(p,a,b)      IUnknown_QueryInterface(p,a,b)
+#define IReferenceClock_AddRef(p)                  IUnknown_AddRef(p)
+#define IReferenceClock_Release(p)                 IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IReferenceClock_GetTime(p,a)               (p)->lpVtbl->GetTime(p,a)
+#define IReferenceClock_AdviseTime(p,a,b,c,d)      (p)->lpVtbl->AdviseTime(p,a,b,c,d)
+#define IReferenceClock_AdvisePeriodic(p,a,b,c,d)  (p)->lpVtbl->AdvisePeriodic(p,a,b,c,d)
+#define IReferenceClock_Unadvise(p,a)              (p)->lpVtbl->Unadvise(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IReferenceClock_GetTime(p,a)               (p)->GetTime(a)
+#define IReferenceClock_AdviseTime(p,a,b,c,d)      (p)->AdviseTime(a,b,c,d)
+#define IReferenceClock_AdvisePeriodic(p,a,b,c,d)  (p)->AdvisePeriodic(a,b,c,d)
+#define IReferenceClock_Unadvise(p,a)              (p)->Unadvise(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // IReferenceClock_QueryInterface
+
+//
+// IDirectSound
+//
+
+DEFINE_GUID(IID_IDirectSound, 0x279AFA83, 0x4981, 0x11CE, 0xA5, 0x21, 0x00, 0x20, 0xAF, 0x0B, 0xE5, 0x60);
+
+#undef INTERFACE
+#define INTERFACE IDirectSound
+
+DECLARE_INTERFACE_(IDirectSound, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSound methods
+    STDMETHOD(CreateSoundBuffer)    (THIS_ LPCDSBUFFERDESC pcDSBufferDesc, LPDIRECTSOUNDBUFFER *ppDSBuffer, LPUNKNOWN pUnkOuter) PURE;
+    STDMETHOD(GetCaps)              (THIS_ LPDSCAPS pDSCaps) PURE;
+    STDMETHOD(DuplicateSoundBuffer) (THIS_ LPDIRECTSOUNDBUFFER pDSBufferOriginal, LPDIRECTSOUNDBUFFER *ppDSBufferDuplicate) PURE;
+    STDMETHOD(SetCooperativeLevel)  (THIS_ HWND hwnd, DWORD dwLevel) PURE;
+    STDMETHOD(Compact)              (THIS) PURE;
+    STDMETHOD(GetSpeakerConfig)     (THIS_ LPDWORD pdwSpeakerConfig) PURE;
+    STDMETHOD(SetSpeakerConfig)     (THIS_ DWORD dwSpeakerConfig) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPCGUID pcGuidDevice) PURE;
+};
+
+#define IDirectSound_QueryInterface(p,a,b)       IUnknown_QueryInterface(p,a,b)
+#define IDirectSound_AddRef(p)                   IUnknown_AddRef(p)
+#define IDirectSound_Release(p)                  IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound_CreateSoundBuffer(p,a,b,c)  (p)->lpVtbl->CreateSoundBuffer(p,a,b,c)
+#define IDirectSound_GetCaps(p,a)                (p)->lpVtbl->GetCaps(p,a)
+#define IDirectSound_DuplicateSoundBuffer(p,a,b) (p)->lpVtbl->DuplicateSoundBuffer(p,a,b)
+#define IDirectSound_SetCooperativeLevel(p,a,b)  (p)->lpVtbl->SetCooperativeLevel(p,a,b)
+#define IDirectSound_Compact(p)                  (p)->lpVtbl->Compact(p)
+#define IDirectSound_GetSpeakerConfig(p,a)       (p)->lpVtbl->GetSpeakerConfig(p,a)
+#define IDirectSound_SetSpeakerConfig(p,b)       (p)->lpVtbl->SetSpeakerConfig(p,b)
+#define IDirectSound_Initialize(p,a)             (p)->lpVtbl->Initialize(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound_CreateSoundBuffer(p,a,b,c)  (p)->CreateSoundBuffer(a,b,c)
+#define IDirectSound_GetCaps(p,a)                (p)->GetCaps(a)
+#define IDirectSound_DuplicateSoundBuffer(p,a,b) (p)->DuplicateSoundBuffer(a,b)
+#define IDirectSound_SetCooperativeLevel(p,a,b)  (p)->SetCooperativeLevel(a,b)
+#define IDirectSound_Compact(p)                  (p)->Compact()
+#define IDirectSound_GetSpeakerConfig(p,a)       (p)->GetSpeakerConfig(a)
+#define IDirectSound_SetSpeakerConfig(p,b)       (p)->SetSpeakerConfig(b)
+#define IDirectSound_Initialize(p,a)             (p)->Initialize(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSound8
+//
+
+DEFINE_GUID(IID_IDirectSound8, 0xC50A7E93, 0xF395, 0x4834, 0x9E, 0xF6, 0x7F, 0xA9, 0x9D, 0xE5, 0x09, 0x66);
+
+#undef INTERFACE
+#define INTERFACE IDirectSound8
+
+DECLARE_INTERFACE_(IDirectSound8, IDirectSound)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSound methods
+    STDMETHOD(CreateSoundBuffer)    (THIS_ LPCDSBUFFERDESC pcDSBufferDesc, LPDIRECTSOUNDBUFFER *ppDSBuffer, LPUNKNOWN pUnkOuter) PURE;
+    STDMETHOD(GetCaps)              (THIS_ LPDSCAPS pDSCaps) PURE;
+    STDMETHOD(DuplicateSoundBuffer) (THIS_ LPDIRECTSOUNDBUFFER pDSBufferOriginal, LPDIRECTSOUNDBUFFER *ppDSBufferDuplicate) PURE;
+    STDMETHOD(SetCooperativeLevel)  (THIS_ HWND hwnd, DWORD dwLevel) PURE;
+    STDMETHOD(Compact)              (THIS) PURE;
+    STDMETHOD(GetSpeakerConfig)     (THIS_ LPDWORD pdwSpeakerConfig) PURE;
+    STDMETHOD(SetSpeakerConfig)     (THIS_ DWORD dwSpeakerConfig) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPCGUID pcGuidDevice) PURE;
+
+    // IDirectSound8 methods
+    STDMETHOD(VerifyCertification)  (THIS_ LPDWORD pdwCertified) PURE;
+};
+
+#define IDirectSound8_QueryInterface(p,a,b)       IDirectSound_QueryInterface(p,a,b)
+#define IDirectSound8_AddRef(p)                   IDirectSound_AddRef(p)
+#define IDirectSound8_Release(p)                  IDirectSound_Release(p)
+#define IDirectSound8_CreateSoundBuffer(p,a,b,c)  IDirectSound_CreateSoundBuffer(p,a,b,c)
+#define IDirectSound8_GetCaps(p,a)                IDirectSound_GetCaps(p,a)
+#define IDirectSound8_DuplicateSoundBuffer(p,a,b) IDirectSound_DuplicateSoundBuffer(p,a,b)
+#define IDirectSound8_SetCooperativeLevel(p,a,b)  IDirectSound_SetCooperativeLevel(p,a,b)
+#define IDirectSound8_Compact(p)                  IDirectSound_Compact(p)
+#define IDirectSound8_GetSpeakerConfig(p,a)       IDirectSound_GetSpeakerConfig(p,a)
+#define IDirectSound8_SetSpeakerConfig(p,a)       IDirectSound_SetSpeakerConfig(p,a)
+#define IDirectSound8_Initialize(p,a)             IDirectSound_Initialize(p,a)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound8_VerifyCertification(p,a)           (p)->lpVtbl->VerifyCertification(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound8_VerifyCertification(p,a)           (p)->VerifyCertification(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSoundBuffer
+//
+
+DEFINE_GUID(IID_IDirectSoundBuffer, 0x279AFA85, 0x4981, 0x11CE, 0xA5, 0x21, 0x00, 0x20, 0xAF, 0x0B, 0xE5, 0x60);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundBuffer
+
+DECLARE_INTERFACE_(IDirectSoundBuffer, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundBuffer methods
+    STDMETHOD(GetCaps)              (THIS_ LPDSBCAPS pDSBufferCaps) PURE;
+    STDMETHOD(GetCurrentPosition)   (THIS_ LPDWORD pdwCurrentPlayCursor, LPDWORD pdwCurrentWriteCursor) PURE;
+    STDMETHOD(GetFormat)            (THIS_ LPWAVEFORMATEX pwfxFormat, DWORD dwSizeAllocated, LPDWORD pdwSizeWritten) PURE;
+    STDMETHOD(GetVolume)            (THIS_ LPLONG plVolume) PURE;
+    STDMETHOD(GetPan)               (THIS_ LPLONG plPan) PURE;
+    STDMETHOD(GetFrequency)         (THIS_ LPDWORD pdwFrequency) PURE;
+    STDMETHOD(GetStatus)            (THIS_ LPDWORD pdwStatus) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPDIRECTSOUND pDirectSound, LPCDSBUFFERDESC pcDSBufferDesc) PURE;
+    STDMETHOD(Lock)                 (THIS_ DWORD dwOffset, DWORD dwBytes, LPVOID *ppvAudioPtr1, LPDWORD pdwAudioBytes1,
+                                           LPVOID *ppvAudioPtr2, LPDWORD pdwAudioBytes2, DWORD dwFlags) PURE;
+    STDMETHOD(Play)                 (THIS_ DWORD dwReserved1, DWORD dwPriority, DWORD dwFlags) PURE;
+    STDMETHOD(SetCurrentPosition)   (THIS_ DWORD dwNewPosition) PURE;
+    STDMETHOD(SetFormat)            (THIS_ LPCWAVEFORMATEX pcfxFormat) PURE;
+    STDMETHOD(SetVolume)            (THIS_ LONG lVolume) PURE;
+    STDMETHOD(SetPan)               (THIS_ LONG lPan) PURE;
+    STDMETHOD(SetFrequency)         (THIS_ DWORD dwFrequency) PURE;
+    STDMETHOD(Stop)                 (THIS) PURE;
+    STDMETHOD(Unlock)               (THIS_ LPVOID pvAudioPtr1, DWORD dwAudioBytes1, LPVOID pvAudioPtr2, DWORD dwAudioBytes2) PURE;
+    STDMETHOD(Restore)              (THIS) PURE;
+};
+
+#define IDirectSoundBuffer_QueryInterface(p,a,b)        IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundBuffer_AddRef(p)                    IUnknown_AddRef(p)
+#define IDirectSoundBuffer_Release(p)                   IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundBuffer_GetCaps(p,a)                 (p)->lpVtbl->GetCaps(p,a)
+#define IDirectSoundBuffer_GetCurrentPosition(p,a,b)    (p)->lpVtbl->GetCurrentPosition(p,a,b)
+#define IDirectSoundBuffer_GetFormat(p,a,b,c)           (p)->lpVtbl->GetFormat(p,a,b,c)
+#define IDirectSoundBuffer_GetVolume(p,a)               (p)->lpVtbl->GetVolume(p,a)
+#define IDirectSoundBuffer_GetPan(p,a)                  (p)->lpVtbl->GetPan(p,a)
+#define IDirectSoundBuffer_GetFrequency(p,a)            (p)->lpVtbl->GetFrequency(p,a)
+#define IDirectSoundBuffer_GetStatus(p,a)               (p)->lpVtbl->GetStatus(p,a)
+#define IDirectSoundBuffer_Initialize(p,a,b)            (p)->lpVtbl->Initialize(p,a,b)
+#define IDirectSoundBuffer_Lock(p,a,b,c,d,e,f,g)        (p)->lpVtbl->Lock(p,a,b,c,d,e,f,g)
+#define IDirectSoundBuffer_Play(p,a,b,c)                (p)->lpVtbl->Play(p,a,b,c)
+#define IDirectSoundBuffer_SetCurrentPosition(p,a)      (p)->lpVtbl->SetCurrentPosition(p,a)
+#define IDirectSoundBuffer_SetFormat(p,a)               (p)->lpVtbl->SetFormat(p,a)
+#define IDirectSoundBuffer_SetVolume(p,a)               (p)->lpVtbl->SetVolume(p,a)
+#define IDirectSoundBuffer_SetPan(p,a)                  (p)->lpVtbl->SetPan(p,a)
+#define IDirectSoundBuffer_SetFrequency(p,a)            (p)->lpVtbl->SetFrequency(p,a)
+#define IDirectSoundBuffer_Stop(p)                      (p)->lpVtbl->Stop(p)
+#define IDirectSoundBuffer_Unlock(p,a,b,c,d)            (p)->lpVtbl->Unlock(p,a,b,c,d)
+#define IDirectSoundBuffer_Restore(p)                   (p)->lpVtbl->Restore(p)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundBuffer_GetCaps(p,a)                 (p)->GetCaps(a)
+#define IDirectSoundBuffer_GetCurrentPosition(p,a,b)    (p)->GetCurrentPosition(a,b)
+#define IDirectSoundBuffer_GetFormat(p,a,b,c)           (p)->GetFormat(a,b,c)
+#define IDirectSoundBuffer_GetVolume(p,a)               (p)->GetVolume(a)
+#define IDirectSoundBuffer_GetPan(p,a)                  (p)->GetPan(a)
+#define IDirectSoundBuffer_GetFrequency(p,a)            (p)->GetFrequency(a)
+#define IDirectSoundBuffer_GetStatus(p,a)               (p)->GetStatus(a)
+#define IDirectSoundBuffer_Initialize(p,a,b)            (p)->Initialize(a,b)
+#define IDirectSoundBuffer_Lock(p,a,b,c,d,e,f,g)        (p)->Lock(a,b,c,d,e,f,g)
+#define IDirectSoundBuffer_Play(p,a,b,c)                (p)->Play(a,b,c)
+#define IDirectSoundBuffer_SetCurrentPosition(p,a)      (p)->SetCurrentPosition(a)
+#define IDirectSoundBuffer_SetFormat(p,a)               (p)->SetFormat(a)
+#define IDirectSoundBuffer_SetVolume(p,a)               (p)->SetVolume(a)
+#define IDirectSoundBuffer_SetPan(p,a)                  (p)->SetPan(a)
+#define IDirectSoundBuffer_SetFrequency(p,a)            (p)->SetFrequency(a)
+#define IDirectSoundBuffer_Stop(p)                      (p)->Stop()
+#define IDirectSoundBuffer_Unlock(p,a,b,c,d)            (p)->Unlock(a,b,c,d)
+#define IDirectSoundBuffer_Restore(p)                   (p)->Restore()
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSoundBuffer8
+//
+
+DEFINE_GUID(IID_IDirectSoundBuffer8, 0x6825a449, 0x7524, 0x4d82, 0x92, 0x0f, 0x50, 0xe3, 0x6a, 0xb3, 0xab, 0x1e);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundBuffer8
+
+DECLARE_INTERFACE_(IDirectSoundBuffer8, IDirectSoundBuffer)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundBuffer methods
+    STDMETHOD(GetCaps)              (THIS_ LPDSBCAPS pDSBufferCaps) PURE;
+    STDMETHOD(GetCurrentPosition)   (THIS_ LPDWORD pdwCurrentPlayCursor, LPDWORD pdwCurrentWriteCursor) PURE;
+    STDMETHOD(GetFormat)            (THIS_ LPWAVEFORMATEX pwfxFormat, DWORD dwSizeAllocated, LPDWORD pdwSizeWritten) PURE;
+    STDMETHOD(GetVolume)            (THIS_ LPLONG plVolume) PURE;
+    STDMETHOD(GetPan)               (THIS_ LPLONG plPan) PURE;
+    STDMETHOD(GetFrequency)         (THIS_ LPDWORD pdwFrequency) PURE;
+    STDMETHOD(GetStatus)            (THIS_ LPDWORD pdwStatus) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPDIRECTSOUND pDirectSound, LPCDSBUFFERDESC pcDSBufferDesc) PURE;
+    STDMETHOD(Lock)                 (THIS_ DWORD dwOffset, DWORD dwBytes, LPVOID *ppvAudioPtr1, LPDWORD pdwAudioBytes1,
+                                           LPVOID *ppvAudioPtr2, LPDWORD pdwAudioBytes2, DWORD dwFlags) PURE;
+    STDMETHOD(Play)                 (THIS_ DWORD dwReserved1, DWORD dwPriority, DWORD dwFlags) PURE;
+    STDMETHOD(SetCurrentPosition)   (THIS_ DWORD dwNewPosition) PURE;
+    STDMETHOD(SetFormat)            (THIS_ LPCWAVEFORMATEX pcfxFormat) PURE;
+    STDMETHOD(SetVolume)            (THIS_ LONG lVolume) PURE;
+    STDMETHOD(SetPan)               (THIS_ LONG lPan) PURE;
+    STDMETHOD(SetFrequency)         (THIS_ DWORD dwFrequency) PURE;
+    STDMETHOD(Stop)                 (THIS) PURE;
+    STDMETHOD(Unlock)               (THIS_ LPVOID pvAudioPtr1, DWORD dwAudioBytes1, LPVOID pvAudioPtr2, DWORD dwAudioBytes2) PURE;
+    STDMETHOD(Restore)              (THIS) PURE;
+
+    // IDirectSoundBuffer8 methods
+    STDMETHOD(SetFX)                (THIS_ DWORD dwEffectsCount, LPDSEFFECTDESC pDSFXDesc, LPDWORD pdwResultCodes) PURE;
+    STDMETHOD(AcquireResources)     (THIS_ DWORD dwFlags, DWORD dwEffectsCount, LPDWORD pdwResultCodes) PURE;
+    STDMETHOD(GetObjectInPath)      (THIS_ REFGUID rguidObject, DWORD dwIndex, REFGUID rguidInterface, LPVOID *ppObject) PURE;
+};
+
+// Special GUID meaning "select all objects" for use in GetObjectInPath()
+DEFINE_GUID(GUID_All_Objects, 0xaa114de5, 0xc262, 0x4169, 0xa1, 0xc8, 0x23, 0xd6, 0x98, 0xcc, 0x73, 0xb5);
+
+#define IDirectSoundBuffer8_QueryInterface(p,a,b)           IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundBuffer8_AddRef(p)                       IUnknown_AddRef(p)
+#define IDirectSoundBuffer8_Release(p)                      IUnknown_Release(p)
+
+#define IDirectSoundBuffer8_GetCaps(p,a)                    IDirectSoundBuffer_GetCaps(p,a)
+#define IDirectSoundBuffer8_GetCurrentPosition(p,a,b)       IDirectSoundBuffer_GetCurrentPosition(p,a,b)
+#define IDirectSoundBuffer8_GetFormat(p,a,b,c)              IDirectSoundBuffer_GetFormat(p,a,b,c)
+#define IDirectSoundBuffer8_GetVolume(p,a)                  IDirectSoundBuffer_GetVolume(p,a)
+#define IDirectSoundBuffer8_GetPan(p,a)                     IDirectSoundBuffer_GetPan(p,a)
+#define IDirectSoundBuffer8_GetFrequency(p,a)               IDirectSoundBuffer_GetFrequency(p,a)
+#define IDirectSoundBuffer8_GetStatus(p,a)                  IDirectSoundBuffer_GetStatus(p,a)
+#define IDirectSoundBuffer8_Initialize(p,a,b)               IDirectSoundBuffer_Initialize(p,a,b)
+#define IDirectSoundBuffer8_Lock(p,a,b,c,d,e,f,g)           IDirectSoundBuffer_Lock(p,a,b,c,d,e,f,g)
+#define IDirectSoundBuffer8_Play(p,a,b,c)                   IDirectSoundBuffer_Play(p,a,b,c)
+#define IDirectSoundBuffer8_SetCurrentPosition(p,a)         IDirectSoundBuffer_SetCurrentPosition(p,a)
+#define IDirectSoundBuffer8_SetFormat(p,a)                  IDirectSoundBuffer_SetFormat(p,a)
+#define IDirectSoundBuffer8_SetVolume(p,a)                  IDirectSoundBuffer_SetVolume(p,a)
+#define IDirectSoundBuffer8_SetPan(p,a)                     IDirectSoundBuffer_SetPan(p,a)
+#define IDirectSoundBuffer8_SetFrequency(p,a)               IDirectSoundBuffer_SetFrequency(p,a)
+#define IDirectSoundBuffer8_Stop(p)                         IDirectSoundBuffer_Stop(p)
+#define IDirectSoundBuffer8_Unlock(p,a,b,c,d)               IDirectSoundBuffer_Unlock(p,a,b,c,d)
+#define IDirectSoundBuffer8_Restore(p)                      IDirectSoundBuffer_Restore(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundBuffer8_SetFX(p,a,b,c)                  (p)->lpVtbl->SetFX(p,a,b,c)
+#define IDirectSoundBuffer8_AcquireResources(p,a,b,c)       (p)->lpVtbl->AcquireResources(p,a,b,c)
+#define IDirectSoundBuffer8_GetObjectInPath(p,a,b,c,d)      (p)->lpVtbl->GetObjectInPath(p,a,b,c,d)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundBuffer8_SetFX(p,a,b,c)                  (p)->SetFX(a,b,c)
+#define IDirectSoundBuffer8_AcquireResources(p,a,b,c)       (p)->AcquireResources(a,b,c)
+#define IDirectSoundBuffer8_GetObjectInPath(p,a,b,c,d)      (p)->GetObjectInPath(a,b,c,d)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSound3DListener
+//
+
+DEFINE_GUID(IID_IDirectSound3DListener, 0x279AFA84, 0x4981, 0x11CE, 0xA5, 0x21, 0x00, 0x20, 0xAF, 0x0B, 0xE5, 0x60);
+
+#undef INTERFACE
+#define INTERFACE IDirectSound3DListener
+
+DECLARE_INTERFACE_(IDirectSound3DListener, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)           (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)            (THIS) PURE;
+    STDMETHOD_(ULONG,Release)           (THIS) PURE;
+
+    // IDirectSound3DListener methods
+    STDMETHOD(GetAllParameters)         (THIS_ LPDS3DLISTENER pListener) PURE;
+    STDMETHOD(GetDistanceFactor)        (THIS_ D3DVALUE* pflDistanceFactor) PURE;
+    STDMETHOD(GetDopplerFactor)         (THIS_ D3DVALUE* pflDopplerFactor) PURE;
+    STDMETHOD(GetOrientation)           (THIS_ D3DVECTOR* pvOrientFront, D3DVECTOR* pvOrientTop) PURE;
+    STDMETHOD(GetPosition)              (THIS_ D3DVECTOR* pvPosition) PURE;
+    STDMETHOD(GetRolloffFactor)         (THIS_ D3DVALUE* pflRolloffFactor) PURE;
+    STDMETHOD(GetVelocity)              (THIS_ D3DVECTOR* pvVelocity) PURE;
+    STDMETHOD(SetAllParameters)         (THIS_ LPCDS3DLISTENER pcListener, DWORD dwApply) PURE;
+    STDMETHOD(SetDistanceFactor)        (THIS_ D3DVALUE flDistanceFactor, DWORD dwApply) PURE;
+    STDMETHOD(SetDopplerFactor)         (THIS_ D3DVALUE flDopplerFactor, DWORD dwApply) PURE;
+    STDMETHOD(SetOrientation)           (THIS_ D3DVALUE xFront, D3DVALUE yFront, D3DVALUE zFront,
+                                               D3DVALUE xTop, D3DVALUE yTop, D3DVALUE zTop, DWORD dwApply) PURE;
+    STDMETHOD(SetPosition)              (THIS_ D3DVALUE x, D3DVALUE y, D3DVALUE z, DWORD dwApply) PURE;
+    STDMETHOD(SetRolloffFactor)         (THIS_ D3DVALUE flRolloffFactor, DWORD dwApply) PURE;
+    STDMETHOD(SetVelocity)              (THIS_ D3DVALUE x, D3DVALUE y, D3DVALUE z, DWORD dwApply) PURE;
+    STDMETHOD(CommitDeferredSettings)   (THIS) PURE;
+};
+
+#define IDirectSound3DListener_QueryInterface(p,a,b)            IUnknown_QueryInterface(p,a,b)
+#define IDirectSound3DListener_AddRef(p)                        IUnknown_AddRef(p)
+#define IDirectSound3DListener_Release(p)                       IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound3DListener_GetAllParameters(p,a)            (p)->lpVtbl->GetAllParameters(p,a)
+#define IDirectSound3DListener_GetDistanceFactor(p,a)           (p)->lpVtbl->GetDistanceFactor(p,a)
+#define IDirectSound3DListener_GetDopplerFactor(p,a)            (p)->lpVtbl->GetDopplerFactor(p,a)
+#define IDirectSound3DListener_GetOrientation(p,a,b)            (p)->lpVtbl->GetOrientation(p,a,b)
+#define IDirectSound3DListener_GetPosition(p,a)                 (p)->lpVtbl->GetPosition(p,a)
+#define IDirectSound3DListener_GetRolloffFactor(p,a)            (p)->lpVtbl->GetRolloffFactor(p,a)
+#define IDirectSound3DListener_GetVelocity(p,a)                 (p)->lpVtbl->GetVelocity(p,a)
+#define IDirectSound3DListener_SetAllParameters(p,a,b)          (p)->lpVtbl->SetAllParameters(p,a,b)
+#define IDirectSound3DListener_SetDistanceFactor(p,a,b)         (p)->lpVtbl->SetDistanceFactor(p,a,b)
+#define IDirectSound3DListener_SetDopplerFactor(p,a,b)          (p)->lpVtbl->SetDopplerFactor(p,a,b)
+#define IDirectSound3DListener_SetOrientation(p,a,b,c,d,e,f,g)  (p)->lpVtbl->SetOrientation(p,a,b,c,d,e,f,g)
+#define IDirectSound3DListener_SetPosition(p,a,b,c,d)           (p)->lpVtbl->SetPosition(p,a,b,c,d)
+#define IDirectSound3DListener_SetRolloffFactor(p,a,b)          (p)->lpVtbl->SetRolloffFactor(p,a,b)
+#define IDirectSound3DListener_SetVelocity(p,a,b,c,d)           (p)->lpVtbl->SetVelocity(p,a,b,c,d)
+#define IDirectSound3DListener_CommitDeferredSettings(p)        (p)->lpVtbl->CommitDeferredSettings(p)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound3DListener_GetAllParameters(p,a)            (p)->GetAllParameters(a)
+#define IDirectSound3DListener_GetDistanceFactor(p,a)           (p)->GetDistanceFactor(a)
+#define IDirectSound3DListener_GetDopplerFactor(p,a)            (p)->GetDopplerFactor(a)
+#define IDirectSound3DListener_GetOrientation(p,a,b)            (p)->GetOrientation(a,b)
+#define IDirectSound3DListener_GetPosition(p,a)                 (p)->GetPosition(a)
+#define IDirectSound3DListener_GetRolloffFactor(p,a)            (p)->GetRolloffFactor(a)
+#define IDirectSound3DListener_GetVelocity(p,a)                 (p)->GetVelocity(a)
+#define IDirectSound3DListener_SetAllParameters(p,a,b)          (p)->SetAllParameters(a,b)
+#define IDirectSound3DListener_SetDistanceFactor(p,a,b)         (p)->SetDistanceFactor(a,b)
+#define IDirectSound3DListener_SetDopplerFactor(p,a,b)          (p)->SetDopplerFactor(a,b)
+#define IDirectSound3DListener_SetOrientation(p,a,b,c,d,e,f,g)  (p)->SetOrientation(a,b,c,d,e,f,g)
+#define IDirectSound3DListener_SetPosition(p,a,b,c,d)           (p)->SetPosition(a,b,c,d)
+#define IDirectSound3DListener_SetRolloffFactor(p,a,b)          (p)->SetRolloffFactor(a,b)
+#define IDirectSound3DListener_SetVelocity(p,a,b,c,d)           (p)->SetVelocity(a,b,c,d)
+#define IDirectSound3DListener_CommitDeferredSettings(p)        (p)->CommitDeferredSettings()
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSound3DBuffer
+//
+
+DEFINE_GUID(IID_IDirectSound3DBuffer, 0x279AFA86, 0x4981, 0x11CE, 0xA5, 0x21, 0x00, 0x20, 0xAF, 0x0B, 0xE5, 0x60);
+
+#undef INTERFACE
+#define INTERFACE IDirectSound3DBuffer
+
+DECLARE_INTERFACE_(IDirectSound3DBuffer, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSound3DBuffer methods
+    STDMETHOD(GetAllParameters)     (THIS_ LPDS3DBUFFER pDs3dBuffer) PURE;
+    STDMETHOD(GetConeAngles)        (THIS_ LPDWORD pdwInsideConeAngle, LPDWORD pdwOutsideConeAngle) PURE;
+    STDMETHOD(GetConeOrientation)   (THIS_ D3DVECTOR* pvOrientation) PURE;
+    STDMETHOD(GetConeOutsideVolume) (THIS_ LPLONG plConeOutsideVolume) PURE;
+    STDMETHOD(GetMaxDistance)       (THIS_ D3DVALUE* pflMaxDistance) PURE;
+    STDMETHOD(GetMinDistance)       (THIS_ D3DVALUE* pflMinDistance) PURE;
+    STDMETHOD(GetMode)              (THIS_ LPDWORD pdwMode) PURE;
+    STDMETHOD(GetPosition)          (THIS_ D3DVECTOR* pvPosition) PURE;
+    STDMETHOD(GetVelocity)          (THIS_ D3DVECTOR* pvVelocity) PURE;
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDS3DBUFFER pcDs3dBuffer, DWORD dwApply) PURE;
+    STDMETHOD(SetConeAngles)        (THIS_ DWORD dwInsideConeAngle, DWORD dwOutsideConeAngle, DWORD dwApply) PURE;
+    STDMETHOD(SetConeOrientation)   (THIS_ D3DVALUE x, D3DVALUE y, D3DVALUE z, DWORD dwApply) PURE;
+    STDMETHOD(SetConeOutsideVolume) (THIS_ LONG lConeOutsideVolume, DWORD dwApply) PURE;
+    STDMETHOD(SetMaxDistance)       (THIS_ D3DVALUE flMaxDistance, DWORD dwApply) PURE;
+    STDMETHOD(SetMinDistance)       (THIS_ D3DVALUE flMinDistance, DWORD dwApply) PURE;
+    STDMETHOD(SetMode)              (THIS_ DWORD dwMode, DWORD dwApply) PURE;
+    STDMETHOD(SetPosition)          (THIS_ D3DVALUE x, D3DVALUE y, D3DVALUE z, DWORD dwApply) PURE;
+    STDMETHOD(SetVelocity)          (THIS_ D3DVALUE x, D3DVALUE y, D3DVALUE z, DWORD dwApply) PURE;
+};
+
+#define IDirectSound3DBuffer_QueryInterface(p,a,b)          IUnknown_QueryInterface(p,a,b)
+#define IDirectSound3DBuffer_AddRef(p)                      IUnknown_AddRef(p)
+#define IDirectSound3DBuffer_Release(p)                     IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound3DBuffer_GetAllParameters(p,a)          (p)->lpVtbl->GetAllParameters(p,a)
+#define IDirectSound3DBuffer_GetConeAngles(p,a,b)           (p)->lpVtbl->GetConeAngles(p,a,b)
+#define IDirectSound3DBuffer_GetConeOrientation(p,a)        (p)->lpVtbl->GetConeOrientation(p,a)
+#define IDirectSound3DBuffer_GetConeOutsideVolume(p,a)      (p)->lpVtbl->GetConeOutsideVolume(p,a)
+#define IDirectSound3DBuffer_GetPosition(p,a)               (p)->lpVtbl->GetPosition(p,a)
+#define IDirectSound3DBuffer_GetMinDistance(p,a)            (p)->lpVtbl->GetMinDistance(p,a)
+#define IDirectSound3DBuffer_GetMaxDistance(p,a)            (p)->lpVtbl->GetMaxDistance(p,a)
+#define IDirectSound3DBuffer_GetMode(p,a)                   (p)->lpVtbl->GetMode(p,a)
+#define IDirectSound3DBuffer_GetVelocity(p,a)               (p)->lpVtbl->GetVelocity(p,a)
+#define IDirectSound3DBuffer_SetAllParameters(p,a,b)        (p)->lpVtbl->SetAllParameters(p,a,b)
+#define IDirectSound3DBuffer_SetConeAngles(p,a,b,c)         (p)->lpVtbl->SetConeAngles(p,a,b,c)
+#define IDirectSound3DBuffer_SetConeOrientation(p,a,b,c,d)  (p)->lpVtbl->SetConeOrientation(p,a,b,c,d)
+#define IDirectSound3DBuffer_SetConeOutsideVolume(p,a,b)    (p)->lpVtbl->SetConeOutsideVolume(p,a,b)
+#define IDirectSound3DBuffer_SetPosition(p,a,b,c,d)         (p)->lpVtbl->SetPosition(p,a,b,c,d)
+#define IDirectSound3DBuffer_SetMinDistance(p,a,b)          (p)->lpVtbl->SetMinDistance(p,a,b)
+#define IDirectSound3DBuffer_SetMaxDistance(p,a,b)          (p)->lpVtbl->SetMaxDistance(p,a,b)
+#define IDirectSound3DBuffer_SetMode(p,a,b)                 (p)->lpVtbl->SetMode(p,a,b)
+#define IDirectSound3DBuffer_SetVelocity(p,a,b,c,d)         (p)->lpVtbl->SetVelocity(p,a,b,c,d)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSound3DBuffer_GetAllParameters(p,a)          (p)->GetAllParameters(a)
+#define IDirectSound3DBuffer_GetConeAngles(p,a,b)           (p)->GetConeAngles(a,b)
+#define IDirectSound3DBuffer_GetConeOrientation(p,a)        (p)->GetConeOrientation(a)
+#define IDirectSound3DBuffer_GetConeOutsideVolume(p,a)      (p)->GetConeOutsideVolume(a)
+#define IDirectSound3DBuffer_GetPosition(p,a)               (p)->GetPosition(a)
+#define IDirectSound3DBuffer_GetMinDistance(p,a)            (p)->GetMinDistance(a)
+#define IDirectSound3DBuffer_GetMaxDistance(p,a)            (p)->GetMaxDistance(a)
+#define IDirectSound3DBuffer_GetMode(p,a)                   (p)->GetMode(a)
+#define IDirectSound3DBuffer_GetVelocity(p,a)               (p)->GetVelocity(a)
+#define IDirectSound3DBuffer_SetAllParameters(p,a,b)        (p)->SetAllParameters(a,b)
+#define IDirectSound3DBuffer_SetConeAngles(p,a,b,c)         (p)->SetConeAngles(a,b,c)
+#define IDirectSound3DBuffer_SetConeOrientation(p,a,b,c,d)  (p)->SetConeOrientation(a,b,c,d)
+#define IDirectSound3DBuffer_SetConeOutsideVolume(p,a,b)    (p)->SetConeOutsideVolume(a,b)
+#define IDirectSound3DBuffer_SetPosition(p,a,b,c,d)         (p)->SetPosition(a,b,c,d)
+#define IDirectSound3DBuffer_SetMinDistance(p,a,b)          (p)->SetMinDistance(a,b)
+#define IDirectSound3DBuffer_SetMaxDistance(p,a,b)          (p)->SetMaxDistance(a,b)
+#define IDirectSound3DBuffer_SetMode(p,a,b)                 (p)->SetMode(a,b)
+#define IDirectSound3DBuffer_SetVelocity(p,a,b,c,d)         (p)->SetVelocity(a,b,c,d)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundCapture
+//
+
+DEFINE_GUID(IID_IDirectSoundCapture, 0xb0210781, 0x89cd, 0x11d0, 0xaf, 0x8, 0x0, 0xa0, 0xc9, 0x25, 0xcd, 0x16);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundCapture
+
+DECLARE_INTERFACE_(IDirectSoundCapture, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundCapture methods
+    STDMETHOD(CreateCaptureBuffer)  (THIS_ LPCDSCBUFFERDESC pcDSCBufferDesc, LPDIRECTSOUNDCAPTUREBUFFER *ppDSCBuffer, LPUNKNOWN pUnkOuter) PURE;
+    STDMETHOD(GetCaps)              (THIS_ LPDSCCAPS pDSCCaps) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPCGUID pcGuidDevice) PURE;
+};
+
+#define IDirectSoundCapture_QueryInterface(p,a,b)           IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundCapture_AddRef(p)                       IUnknown_AddRef(p)
+#define IDirectSoundCapture_Release(p)                      IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCapture_CreateCaptureBuffer(p,a,b,c)    (p)->lpVtbl->CreateCaptureBuffer(p,a,b,c)
+#define IDirectSoundCapture_GetCaps(p,a)                    (p)->lpVtbl->GetCaps(p,a)
+#define IDirectSoundCapture_Initialize(p,a)                 (p)->lpVtbl->Initialize(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCapture_CreateCaptureBuffer(p,a,b,c)    (p)->CreateCaptureBuffer(a,b,c)
+#define IDirectSoundCapture_GetCaps(p,a)                    (p)->GetCaps(a)
+#define IDirectSoundCapture_Initialize(p,a)                 (p)->Initialize(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundCaptureBuffer
+//
+
+DEFINE_GUID(IID_IDirectSoundCaptureBuffer, 0xb0210782, 0x89cd, 0x11d0, 0xaf, 0x8, 0x0, 0xa0, 0xc9, 0x25, 0xcd, 0x16);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundCaptureBuffer
+
+DECLARE_INTERFACE_(IDirectSoundCaptureBuffer, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundCaptureBuffer methods
+    STDMETHOD(GetCaps)              (THIS_ LPDSCBCAPS pDSCBCaps) PURE;
+    STDMETHOD(GetCurrentPosition)   (THIS_ LPDWORD pdwCapturePosition, LPDWORD pdwReadPosition) PURE;
+    STDMETHOD(GetFormat)            (THIS_ LPWAVEFORMATEX pwfxFormat, DWORD dwSizeAllocated, LPDWORD pdwSizeWritten) PURE;
+    STDMETHOD(GetStatus)            (THIS_ LPDWORD pdwStatus) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPDIRECTSOUNDCAPTURE pDirectSoundCapture, LPCDSCBUFFERDESC pcDSCBufferDesc) PURE;
+    STDMETHOD(Lock)                 (THIS_ DWORD dwOffset, DWORD dwBytes, LPVOID *ppvAudioPtr1, LPDWORD pdwAudioBytes1,
+                                           LPVOID *ppvAudioPtr2, LPDWORD pdwAudioBytes2, DWORD dwFlags) PURE;
+    STDMETHOD(Start)                (THIS_ DWORD dwFlags) PURE;
+    STDMETHOD(Stop)                 (THIS) PURE;
+    STDMETHOD(Unlock)               (THIS_ LPVOID pvAudioPtr1, DWORD dwAudioBytes1, LPVOID pvAudioPtr2, DWORD dwAudioBytes2) PURE;
+};
+
+#define IDirectSoundCaptureBuffer_QueryInterface(p,a,b)         IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundCaptureBuffer_AddRef(p)                     IUnknown_AddRef(p)
+#define IDirectSoundCaptureBuffer_Release(p)                    IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureBuffer_GetCaps(p,a)                  (p)->lpVtbl->GetCaps(p,a)
+#define IDirectSoundCaptureBuffer_GetCurrentPosition(p,a,b)     (p)->lpVtbl->GetCurrentPosition(p,a,b)
+#define IDirectSoundCaptureBuffer_GetFormat(p,a,b,c)            (p)->lpVtbl->GetFormat(p,a,b,c)
+#define IDirectSoundCaptureBuffer_GetStatus(p,a)                (p)->lpVtbl->GetStatus(p,a)
+#define IDirectSoundCaptureBuffer_Initialize(p,a,b)             (p)->lpVtbl->Initialize(p,a,b)
+#define IDirectSoundCaptureBuffer_Lock(p,a,b,c,d,e,f,g)         (p)->lpVtbl->Lock(p,a,b,c,d,e,f,g)
+#define IDirectSoundCaptureBuffer_Start(p,a)                    (p)->lpVtbl->Start(p,a)
+#define IDirectSoundCaptureBuffer_Stop(p)                       (p)->lpVtbl->Stop(p)
+#define IDirectSoundCaptureBuffer_Unlock(p,a,b,c,d)             (p)->lpVtbl->Unlock(p,a,b,c,d)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureBuffer_GetCaps(p,a)                  (p)->GetCaps(a)
+#define IDirectSoundCaptureBuffer_GetCurrentPosition(p,a,b)     (p)->GetCurrentPosition(a,b)
+#define IDirectSoundCaptureBuffer_GetFormat(p,a,b,c)            (p)->GetFormat(a,b,c)
+#define IDirectSoundCaptureBuffer_GetStatus(p,a)                (p)->GetStatus(a)
+#define IDirectSoundCaptureBuffer_Initialize(p,a,b)             (p)->Initialize(a,b)
+#define IDirectSoundCaptureBuffer_Lock(p,a,b,c,d,e,f,g)         (p)->Lock(a,b,c,d,e,f,g)
+#define IDirectSoundCaptureBuffer_Start(p,a)                    (p)->Start(a)
+#define IDirectSoundCaptureBuffer_Stop(p)                       (p)->Stop()
+#define IDirectSoundCaptureBuffer_Unlock(p,a,b,c,d)             (p)->Unlock(a,b,c,d)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSoundCaptureBuffer8
+//
+
+DEFINE_GUID(IID_IDirectSoundCaptureBuffer8, 0x990df4, 0xdbb, 0x4872, 0x83, 0x3e, 0x6d, 0x30, 0x3e, 0x80, 0xae, 0xb6);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundCaptureBuffer8
+
+DECLARE_INTERFACE_(IDirectSoundCaptureBuffer8, IDirectSoundCaptureBuffer)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundCaptureBuffer methods
+    STDMETHOD(GetCaps)              (THIS_ LPDSCBCAPS pDSCBCaps) PURE;
+    STDMETHOD(GetCurrentPosition)   (THIS_ LPDWORD pdwCapturePosition, LPDWORD pdwReadPosition) PURE;
+    STDMETHOD(GetFormat)            (THIS_ LPWAVEFORMATEX pwfxFormat, DWORD dwSizeAllocated, LPDWORD pdwSizeWritten) PURE;
+    STDMETHOD(GetStatus)            (THIS_ LPDWORD pdwStatus) PURE;
+    STDMETHOD(Initialize)           (THIS_ LPDIRECTSOUNDCAPTURE pDirectSoundCapture, LPCDSCBUFFERDESC pcDSCBufferDesc) PURE;
+    STDMETHOD(Lock)                 (THIS_ DWORD dwOffset, DWORD dwBytes, LPVOID *ppvAudioPtr1, LPDWORD pdwAudioBytes1,
+                                           LPVOID *ppvAudioPtr2, LPDWORD pdwAudioBytes2, DWORD dwFlags) PURE;
+    STDMETHOD(Start)                (THIS_ DWORD dwFlags) PURE;
+    STDMETHOD(Stop)                 (THIS) PURE;
+    STDMETHOD(Unlock)               (THIS_ LPVOID pvAudioPtr1, DWORD dwAudioBytes1, LPVOID pvAudioPtr2, DWORD dwAudioBytes2) PURE;
+
+    // IDirectSoundCaptureBuffer8 methods
+    STDMETHOD(GetObjectInPath)      (THIS_ REFGUID rguidObject, DWORD dwIndex, REFGUID rguidInterface, LPVOID *ppObject) PURE;
+    STDMETHOD(GetFXStatus)          (DWORD dwFXCount, LPDWORD pdwFXStatus) PURE;
+};
+
+#define IDirectSoundCaptureBuffer8_QueryInterface(p,a,b)            IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundCaptureBuffer8_AddRef(p)                        IUnknown_AddRef(p)
+#define IDirectSoundCaptureBuffer8_Release(p)                       IUnknown_Release(p)
+
+#define IDirectSoundCaptureBuffer8_GetCaps(p,a)                     IDirectSoundCaptureBuffer_GetCaps(p,a)
+#define IDirectSoundCaptureBuffer8_GetCurrentPosition(p,a,b)        IDirectSoundCaptureBuffer_GetCurrentPosition(p,a,b)
+#define IDirectSoundCaptureBuffer8_GetFormat(p,a,b,c)               IDirectSoundCaptureBuffer_GetFormat(p,a,b,c)
+#define IDirectSoundCaptureBuffer8_GetStatus(p,a)                   IDirectSoundCaptureBuffer_GetStatus(p,a)
+#define IDirectSoundCaptureBuffer8_Initialize(p,a,b)                IDirectSoundCaptureBuffer_Initialize(p,a,b)
+#define IDirectSoundCaptureBuffer8_Lock(p,a,b,c,d,e,f,g)            IDirectSoundCaptureBuffer_Lock(p,a,b,c,d,e,f,g)
+#define IDirectSoundCaptureBuffer8_Start(p,a)                       IDirectSoundCaptureBuffer_Start(p,a)
+#define IDirectSoundCaptureBuffer8_Stop(p)                          IDirectSoundCaptureBuffer_Stop(p))
+#define IDirectSoundCaptureBuffer8_Unlock(p,a,b,c,d)                IDirectSoundCaptureBuffer_Unlock(p,a,b,c,d)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureBuffer8_GetObjectInPath(p,a,b,c,d)       (p)->lpVtbl->GetObjectInPath(p,a,b,c,d)
+#define IDirectSoundCaptureBuffer8_GetFXStatus(p,a,b)               (p)->lpVtbl->GetFXStatus(p,a,b)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureBuffer8_GetObjectInPath(p,a,b,c,d)       (p)->GetObjectInPath(a,b,c,d)
+#define IDirectSoundCaptureBuffer8_GetFXStatus(p,a,b)               (p)->GetFXStatus(a,b)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSoundNotify
+//
+
+DEFINE_GUID(IID_IDirectSoundNotify, 0xb0210783, 0x89cd, 0x11d0, 0xaf, 0x8, 0x0, 0xa0, 0xc9, 0x25, 0xcd, 0x16);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundNotify
+
+DECLARE_INTERFACE_(IDirectSoundNotify, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)           (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)            (THIS) PURE;
+    STDMETHOD_(ULONG,Release)           (THIS) PURE;
+
+    // IDirectSoundNotify methods
+    STDMETHOD(SetNotificationPositions) (THIS_ DWORD dwPositionNotifies, LPCDSBPOSITIONNOTIFY pcPositionNotifies) PURE;
+};
+
+#define IDirectSoundNotify_QueryInterface(p,a,b)            IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundNotify_AddRef(p)                        IUnknown_AddRef(p)
+#define IDirectSoundNotify_Release(p)                       IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundNotify_SetNotificationPositions(p,a,b)  (p)->lpVtbl->SetNotificationPositions(p,a,b)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundNotify_SetNotificationPositions(p,a,b)  (p)->SetNotificationPositions(a,b)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IKsPropertySet
+//
+
+#ifndef _IKsPropertySet_
+#define _IKsPropertySet_
+
+#ifdef __cplusplus
+// 'struct' not 'class' per the way DECLARE_INTERFACE_ is defined
+struct IKsPropertySet;
+#endif // __cplusplus
+
+typedef struct IKsPropertySet *LPKSPROPERTYSET;
+
+#define KSPROPERTY_SUPPORT_GET  0x00000001
+#define KSPROPERTY_SUPPORT_SET  0x00000002
+
+DEFINE_GUID(IID_IKsPropertySet, 0x31efac30, 0x515c, 0x11d0, 0xa9, 0xaa, 0x00, 0xaa, 0x00, 0x61, 0xbe, 0x93);
+
+#undef INTERFACE
+#define INTERFACE IKsPropertySet
+
+DECLARE_INTERFACE_(IKsPropertySet, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)   (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)    (THIS) PURE;
+    STDMETHOD_(ULONG,Release)   (THIS) PURE;
+
+    // IKsPropertySet methods
+    STDMETHOD(Get)              (THIS_ REFGUID rguidPropSet, ULONG ulId, LPVOID pInstanceData, ULONG ulInstanceLength,
+                                       LPVOID pPropertyData, ULONG ulDataLength, PULONG pulBytesReturned) PURE;
+    STDMETHOD(Set)              (THIS_ REFGUID rguidPropSet, ULONG ulId, LPVOID pInstanceData, ULONG ulInstanceLength,
+                                       LPVOID pPropertyData, ULONG ulDataLength) PURE;
+    STDMETHOD(QuerySupport)     (THIS_ REFGUID rguidPropSet, ULONG ulId, PULONG pulTypeSupport) PURE;
+};
+
+#define IKsPropertySet_QueryInterface(p,a,b)       IUnknown_QueryInterface(p,a,b)
+#define IKsPropertySet_AddRef(p)                   IUnknown_AddRef(p)
+#define IKsPropertySet_Release(p)                  IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IKsPropertySet_Get(p,a,b,c,d,e,f,g)        (p)->lpVtbl->Get(p,a,b,c,d,e,f,g)
+#define IKsPropertySet_Set(p,a,b,c,d,e,f)          (p)->lpVtbl->Set(p,a,b,c,d,e,f)
+#define IKsPropertySet_QuerySupport(p,a,b,c)       (p)->lpVtbl->QuerySupport(p,a,b,c)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IKsPropertySet_Get(p,a,b,c,d,e,f,g)        (p)->Get(a,b,c,d,e,f,g)
+#define IKsPropertySet_Set(p,a,b,c,d,e,f)          (p)->Set(a,b,c,d,e,f)
+#define IKsPropertySet_QuerySupport(p,a,b,c)       (p)->QuerySupport(a,b,c)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // _IKsPropertySet_
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+//
+// IDirectSoundFXGargle
+//
+
+DEFINE_GUID(IID_IDirectSoundFXGargle, 0xd616f352, 0xd622, 0x11ce, 0xaa, 0xc5, 0x00, 0x20, 0xaf, 0x0b, 0x99, 0xa3);
+
+typedef struct _DSFXGargle
+{
+    DWORD       dwRateHz;               // Rate of modulation in hz
+    DWORD       dwWaveShape;            // DSFXGARGLE_WAVE_xxx
+} DSFXGargle, *LPDSFXGargle;
+
+#define DSFXGARGLE_WAVE_TRIANGLE        0
+#define DSFXGARGLE_WAVE_SQUARE          1
+
+typedef const DSFXGargle *LPCDSFXGargle;
+
+#define DSFXGARGLE_RATEHZ_MIN           1
+#define DSFXGARGLE_RATEHZ_MAX           1000
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXGargle
+
+DECLARE_INTERFACE_(IDirectSoundFXGargle, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXGargle methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXGargle pcDsFxGargle) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXGargle pDsFxGargle) PURE;
+};
+
+#define IDirectSoundFXGargle_QueryInterface(p,a,b)          IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXGargle_AddRef(p)                      IUnknown_AddRef(p)
+#define IDirectSoundFXGargle_Release(p)                     IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXGargle_SetAllParameters(p,a)          (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXGargle_GetAllParameters(p,a)          (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXGargle_SetAllParameters(p,a)          (p)->SetAllParameters(a)
+#define IDirectSoundFXGargle_GetAllParameters(p,a)          (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXChorus
+//
+
+DEFINE_GUID(IID_IDirectSoundFXChorus, 0x880842e3, 0x145f, 0x43e6, 0xa9, 0x34, 0xa7, 0x18, 0x06, 0xe5, 0x05, 0x47);
+
+typedef struct _DSFXChorus
+{
+    FLOAT       fWetDryMix;
+    FLOAT       fDepth;
+    FLOAT       fFeedback;
+    FLOAT       fFrequency;
+    LONG        lWaveform;          // LFO shape; DSFXCHORUS_WAVE_xxx
+    FLOAT       fDelay;
+    LONG        lPhase;
+} DSFXChorus, *LPDSFXChorus;
+
+typedef const DSFXChorus *LPCDSFXChorus;
+
+#define DSFXCHORUS_WAVE_TRIANGLE        0
+#define DSFXCHORUS_WAVE_SIN             1
+
+#define DSFXCHORUS_WETDRYMIX_MIN        0.0f
+#define DSFXCHORUS_WETDRYMIX_MAX        100.0f
+#define DSFXCHORUS_DEPTH_MIN            0.0f
+#define DSFXCHORUS_DEPTH_MAX            100.0f
+#define DSFXCHORUS_FEEDBACK_MIN         -99.0f
+#define DSFXCHORUS_FEEDBACK_MAX         99.0f
+#define DSFXCHORUS_FREQUENCY_MIN        0.0f
+#define DSFXCHORUS_FREQUENCY_MAX        10.0f
+#define DSFXCHORUS_DELAY_MIN            0.0f
+#define DSFXCHORUS_DELAY_MAX            20.0f
+#define DSFXCHORUS_PHASE_MIN            0
+#define DSFXCHORUS_PHASE_MAX            4
+
+#define DSFXCHORUS_PHASE_NEG_180        0
+#define DSFXCHORUS_PHASE_NEG_90         1
+#define DSFXCHORUS_PHASE_ZERO           2
+#define DSFXCHORUS_PHASE_90             3
+#define DSFXCHORUS_PHASE_180            4
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXChorus
+
+DECLARE_INTERFACE_(IDirectSoundFXChorus, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXChorus methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXChorus pcDsFxChorus) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXChorus pDsFxChorus) PURE;
+};
+
+#define IDirectSoundFXChorus_QueryInterface(p,a,b)          IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXChorus_AddRef(p)                      IUnknown_AddRef(p)
+#define IDirectSoundFXChorus_Release(p)                     IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXChorus_SetAllParameters(p,a)          (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXChorus_GetAllParameters(p,a)          (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXChorus_SetAllParameters(p,a)          (p)->SetAllParameters(a)
+#define IDirectSoundFXChorus_GetAllParameters(p,a)          (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXFlanger
+//
+
+DEFINE_GUID(IID_IDirectSoundFXFlanger, 0x903e9878, 0x2c92, 0x4072, 0x9b, 0x2c, 0xea, 0x68, 0xf5, 0x39, 0x67, 0x83);
+
+typedef struct _DSFXFlanger
+{
+    FLOAT       fWetDryMix;
+    FLOAT       fDepth;
+    FLOAT       fFeedback;
+    FLOAT       fFrequency;
+    LONG        lWaveform;
+    FLOAT       fDelay;
+    LONG        lPhase;
+} DSFXFlanger, *LPDSFXFlanger;
+
+typedef const DSFXFlanger *LPCDSFXFlanger;
+
+#define DSFXFLANGER_WAVE_TRIANGLE       0
+#define DSFXFLANGER_WAVE_SIN            1
+
+#define DSFXFLANGER_WETDRYMIX_MIN       0.0f
+#define DSFXFLANGER_WETDRYMIX_MAX       100.0f
+#define DSFXFLANGER_FREQUENCY_MIN       0.0f
+#define DSFXFLANGER_FREQUENCY_MAX       10.0f
+#define DSFXFLANGER_DEPTH_MIN           0.0f
+#define DSFXFLANGER_DEPTH_MAX           100.0f
+#define DSFXFLANGER_PHASE_MIN           0
+#define DSFXFLANGER_PHASE_MAX           4
+#define DSFXFLANGER_FEEDBACK_MIN        -99.0f
+#define DSFXFLANGER_FEEDBACK_MAX        99.0f
+#define DSFXFLANGER_DELAY_MIN           0.0f
+#define DSFXFLANGER_DELAY_MAX           4.0f
+
+#define DSFXFLANGER_PHASE_NEG_180       0
+#define DSFXFLANGER_PHASE_NEG_90        1
+#define DSFXFLANGER_PHASE_ZERO          2
+#define DSFXFLANGER_PHASE_90            3
+#define DSFXFLANGER_PHASE_180           4
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXFlanger
+
+DECLARE_INTERFACE_(IDirectSoundFXFlanger, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXFlanger methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXFlanger pcDsFxFlanger) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXFlanger pDsFxFlanger) PURE;
+};
+
+#define IDirectSoundFXFlanger_QueryInterface(p,a,b)         IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXFlanger_AddRef(p)                     IUnknown_AddRef(p)
+#define IDirectSoundFXFlanger_Release(p)                    IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXFlanger_SetAllParameters(p,a)         (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXFlanger_GetAllParameters(p,a)         (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXFlanger_SetAllParameters(p,a)         (p)->SetAllParameters(a)
+#define IDirectSoundFXFlanger_GetAllParameters(p,a)         (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXEcho
+//
+
+DEFINE_GUID(IID_IDirectSoundFXEcho, 0x8bd28edf, 0x50db, 0x4e92, 0xa2, 0xbd, 0x44, 0x54, 0x88, 0xd1, 0xed, 0x42);
+
+typedef struct _DSFXEcho
+{
+    FLOAT   fWetDryMix;
+    FLOAT   fFeedback;
+    FLOAT   fLeftDelay;
+    FLOAT   fRightDelay;
+    LONG    lPanDelay;
+} DSFXEcho, *LPDSFXEcho;
+
+typedef const DSFXEcho *LPCDSFXEcho;
+
+#define DSFXECHO_WETDRYMIX_MIN      0.0f
+#define DSFXECHO_WETDRYMIX_MAX      100.0f
+#define DSFXECHO_FEEDBACK_MIN       0.0f
+#define DSFXECHO_FEEDBACK_MAX       100.0f
+#define DSFXECHO_LEFTDELAY_MIN      1.0f
+#define DSFXECHO_LEFTDELAY_MAX      2000.0f
+#define DSFXECHO_RIGHTDELAY_MIN     1.0f
+#define DSFXECHO_RIGHTDELAY_MAX     2000.0f
+#define DSFXECHO_PANDELAY_MIN       0
+#define DSFXECHO_PANDELAY_MAX       1
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXEcho
+
+DECLARE_INTERFACE_(IDirectSoundFXEcho, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXEcho methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXEcho pcDsFxEcho) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXEcho pDsFxEcho) PURE;
+};
+
+#define IDirectSoundFXEcho_QueryInterface(p,a,b)            IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXEcho_AddRef(p)                        IUnknown_AddRef(p)
+#define IDirectSoundFXEcho_Release(p)                       IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXEcho_SetAllParameters(p,a)            (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXEcho_GetAllParameters(p,a)            (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXEcho_SetAllParameters(p,a)            (p)->SetAllParameters(a)
+#define IDirectSoundFXEcho_GetAllParameters(p,a)            (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXDistortion
+//
+
+DEFINE_GUID(IID_IDirectSoundFXDistortion, 0x8ecf4326, 0x455f, 0x4d8b, 0xbd, 0xa9, 0x8d, 0x5d, 0x3e, 0x9e, 0x3e, 0x0b);
+
+typedef struct _DSFXDistortion
+{
+    FLOAT   fGain;
+    FLOAT   fEdge;
+    FLOAT   fPostEQCenterFrequency;
+    FLOAT   fPostEQBandwidth;
+    FLOAT   fPreLowpassCutoff;
+} DSFXDistortion, *LPDSFXDistortion;
+
+typedef const DSFXDistortion *LPCDSFXDistortion;
+
+#define DSFXDISTORTION_GAIN_MIN                     -60.0f
+#define DSFXDISTORTION_GAIN_MAX                     0.0f
+#define DSFXDISTORTION_EDGE_MIN                     0.0f
+#define DSFXDISTORTION_EDGE_MAX                     100.0f
+#define DSFXDISTORTION_POSTEQCENTERFREQUENCY_MIN    100.0f
+#define DSFXDISTORTION_POSTEQCENTERFREQUENCY_MAX    8000.0f
+#define DSFXDISTORTION_POSTEQBANDWIDTH_MIN          100.0f
+#define DSFXDISTORTION_POSTEQBANDWIDTH_MAX          8000.0f
+#define DSFXDISTORTION_PRELOWPASSCUTOFF_MIN         100.0f
+#define DSFXDISTORTION_PRELOWPASSCUTOFF_MAX         8000.0f
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXDistortion
+
+DECLARE_INTERFACE_(IDirectSoundFXDistortion, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXDistortion methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXDistortion pcDsFxDistortion) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXDistortion pDsFxDistortion) PURE;
+};
+
+#define IDirectSoundFXDistortion_QueryInterface(p,a,b)      IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXDistortion_AddRef(p)                  IUnknown_AddRef(p)
+#define IDirectSoundFXDistortion_Release(p)                 IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXDistortion_SetAllParameters(p,a)      (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXDistortion_GetAllParameters(p,a)      (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXDistortion_SetAllParameters(p,a)      (p)->SetAllParameters(a)
+#define IDirectSoundFXDistortion_GetAllParameters(p,a)      (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXCompressor
+//
+
+DEFINE_GUID(IID_IDirectSoundFXCompressor, 0x4bbd1154, 0x62f6, 0x4e2c, 0xa1, 0x5c, 0xd3, 0xb6, 0xc4, 0x17, 0xf7, 0xa0);
+
+typedef struct _DSFXCompressor
+{
+    FLOAT   fGain;
+    FLOAT   fAttack;
+    FLOAT   fRelease;
+    FLOAT   fThreshold;
+    FLOAT   fRatio;
+    FLOAT   fPredelay;
+} DSFXCompressor, *LPDSFXCompressor;
+
+typedef const DSFXCompressor *LPCDSFXCompressor;
+
+#define DSFXCOMPRESSOR_GAIN_MIN             -60.0f
+#define DSFXCOMPRESSOR_GAIN_MAX             60.0f
+#define DSFXCOMPRESSOR_ATTACK_MIN           0.01f
+#define DSFXCOMPRESSOR_ATTACK_MAX           500.0f
+#define DSFXCOMPRESSOR_RELEASE_MIN          50.0f
+#define DSFXCOMPRESSOR_RELEASE_MAX          3000.0f
+#define DSFXCOMPRESSOR_THRESHOLD_MIN        -60.0f
+#define DSFXCOMPRESSOR_THRESHOLD_MAX        0.0f
+#define DSFXCOMPRESSOR_RATIO_MIN            1.0f
+#define DSFXCOMPRESSOR_RATIO_MAX            100.0f
+#define DSFXCOMPRESSOR_PREDELAY_MIN         0.0f
+#define DSFXCOMPRESSOR_PREDELAY_MAX         4.0f
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXCompressor
+
+DECLARE_INTERFACE_(IDirectSoundFXCompressor, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXCompressor methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXCompressor pcDsFxCompressor) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXCompressor pDsFxCompressor) PURE;
+};
+
+#define IDirectSoundFXCompressor_QueryInterface(p,a,b)      IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXCompressor_AddRef(p)                  IUnknown_AddRef(p)
+#define IDirectSoundFXCompressor_Release(p)                 IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXCompressor_SetAllParameters(p,a)      (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXCompressor_GetAllParameters(p,a)      (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXCompressor_SetAllParameters(p,a)      (p)->SetAllParameters(a)
+#define IDirectSoundFXCompressor_GetAllParameters(p,a)      (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundFXParamEq
+//
+
+DEFINE_GUID(IID_IDirectSoundFXParamEq, 0xc03ca9fe, 0xfe90, 0x4204, 0x80, 0x78, 0x82, 0x33, 0x4c, 0xd1, 0x77, 0xda);
+
+typedef struct _DSFXParamEq
+{
+    FLOAT   fCenter;
+    FLOAT   fBandwidth;
+    FLOAT   fGain;
+} DSFXParamEq, *LPDSFXParamEq;
+
+typedef const DSFXParamEq *LPCDSFXParamEq;
+
+#define DSFXPARAMEQ_CENTER_MIN      80.0f
+#define DSFXPARAMEQ_CENTER_MAX      16000.0f
+#define DSFXPARAMEQ_BANDWIDTH_MIN   1.0f
+#define DSFXPARAMEQ_BANDWIDTH_MAX   36.0f
+#define DSFXPARAMEQ_GAIN_MIN        -15.0f
+#define DSFXPARAMEQ_GAIN_MAX        15.0f
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXParamEq
+
+DECLARE_INTERFACE_(IDirectSoundFXParamEq, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXParamEq methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXParamEq pcDsFxParamEq) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXParamEq pDsFxParamEq) PURE;
+};
+
+#define IDirectSoundFXParamEq_QueryInterface(p,a,b)      IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXParamEq_AddRef(p)                  IUnknown_AddRef(p)
+#define IDirectSoundFXParamEq_Release(p)                 IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXParamEq_SetAllParameters(p,a)      (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXParamEq_GetAllParameters(p,a)      (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXParamEq_SetAllParameters(p,a)      (p)->SetAllParameters(a)
+#define IDirectSoundFXParamEq_GetAllParameters(p,a)      (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+
+//
+// IDirectSoundFXI3DL2Reverb
+//
+
+DEFINE_GUID(IID_IDirectSoundFXI3DL2Reverb, 0x4b166a6a, 0x0d66, 0x43f3, 0x80, 0xe3, 0xee, 0x62, 0x80, 0xde, 0xe1, 0xa4);
+
+typedef struct _DSFXI3DL2Reverb
+{
+    LONG    lRoom;                  // [-10000, 0]      default: -1000 mB
+    LONG    lRoomHF;                // [-10000, 0]      default: 0 mB
+    FLOAT   flRoomRolloffFactor;    // [0.0, 10.0]      default: 0.0
+    FLOAT   flDecayTime;            // [0.1, 20.0]      default: 1.49s
+    FLOAT   flDecayHFRatio;         // [0.1, 2.0]       default: 0.83
+    LONG    lReflections;           // [-10000, 1000]   default: -2602 mB
+    FLOAT   flReflectionsDelay;     // [0.0, 0.3]       default: 0.007 s
+    LONG    lReverb;                // [-10000, 2000]   default: 200 mB
+    FLOAT   flReverbDelay;          // [0.0, 0.1]       default: 0.011 s
+    FLOAT   flDiffusion;            // [0.0, 100.0]     default: 100.0 %
+    FLOAT   flDensity;              // [0.0, 100.0]     default: 100.0 %
+    FLOAT   flHFReference;          // [20.0, 20000.0]  default: 5000.0 Hz
+} DSFXI3DL2Reverb, *LPDSFXI3DL2Reverb;
+
+typedef const DSFXI3DL2Reverb *LPCDSFXI3DL2Reverb;
+
+#define DSFX_I3DL2REVERB_ROOM_MIN                   (-10000)
+#define DSFX_I3DL2REVERB_ROOM_MAX                   0
+#define DSFX_I3DL2REVERB_ROOM_DEFAULT               (-1000)
+                                                    
+#define DSFX_I3DL2REVERB_ROOMHF_MIN                 (-10000)
+#define DSFX_I3DL2REVERB_ROOMHF_MAX                 0
+#define DSFX_I3DL2REVERB_ROOMHF_DEFAULT             (-100)
+                                                    
+#define DSFX_I3DL2REVERB_ROOMROLLOFFFACTOR_MIN      0.0f
+#define DSFX_I3DL2REVERB_ROOMROLLOFFFACTOR_MAX      10.0f
+#define DSFX_I3DL2REVERB_ROOMROLLOFFFACTOR_DEFAULT  0.0f
+
+#define DSFX_I3DL2REVERB_DECAYTIME_MIN              0.1f
+#define DSFX_I3DL2REVERB_DECAYTIME_MAX              20.0f
+#define DSFX_I3DL2REVERB_DECAYTIME_DEFAULT          1.49f
+                                                    
+#define DSFX_I3DL2REVERB_DECAYHFRATIO_MIN           0.1f
+#define DSFX_I3DL2REVERB_DECAYHFRATIO_MAX           2.0f
+#define DSFX_I3DL2REVERB_DECAYHFRATIO_DEFAULT       0.83f
+                                                    
+#define DSFX_I3DL2REVERB_REFLECTIONS_MIN            (-10000)
+#define DSFX_I3DL2REVERB_REFLECTIONS_MAX            1000
+#define DSFX_I3DL2REVERB_REFLECTIONS_DEFAULT        (-2602)
+                                                    
+#define DSFX_I3DL2REVERB_REFLECTIONSDELAY_MIN       0.0f
+#define DSFX_I3DL2REVERB_REFLECTIONSDELAY_MAX       0.3f
+#define DSFX_I3DL2REVERB_REFLECTIONSDELAY_DEFAULT   0.007f
+
+#define DSFX_I3DL2REVERB_REVERB_MIN                 (-10000)
+#define DSFX_I3DL2REVERB_REVERB_MAX                 2000
+#define DSFX_I3DL2REVERB_REVERB_DEFAULT             (200)
+                                                    
+#define DSFX_I3DL2REVERB_REVERBDELAY_MIN            0.0f
+#define DSFX_I3DL2REVERB_REVERBDELAY_MAX            0.1f
+#define DSFX_I3DL2REVERB_REVERBDELAY_DEFAULT        0.011f
+                                                    
+#define DSFX_I3DL2REVERB_DIFFUSION_MIN              0.0f
+#define DSFX_I3DL2REVERB_DIFFUSION_MAX              100.0f
+#define DSFX_I3DL2REVERB_DIFFUSION_DEFAULT          100.0f
+                                                    
+#define DSFX_I3DL2REVERB_DENSITY_MIN                0.0f
+#define DSFX_I3DL2REVERB_DENSITY_MAX                100.0f
+#define DSFX_I3DL2REVERB_DENSITY_DEFAULT            100.0f
+                                                    
+#define DSFX_I3DL2REVERB_HFREFERENCE_MIN            20.0f
+#define DSFX_I3DL2REVERB_HFREFERENCE_MAX            20000.0f
+#define DSFX_I3DL2REVERB_HFREFERENCE_DEFAULT        5000.0f
+                                                    
+#define DSFX_I3DL2REVERB_QUALITY_MIN                0
+#define DSFX_I3DL2REVERB_QUALITY_MAX                3
+#define DSFX_I3DL2REVERB_QUALITY_DEFAULT            2
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXI3DL2Reverb
+
+DECLARE_INTERFACE_(IDirectSoundFXI3DL2Reverb, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXI3DL2Reverb methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXI3DL2Reverb pcDsFxI3DL2Reverb) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXI3DL2Reverb pDsFxI3DL2Reverb) PURE;
+    STDMETHOD(SetPreset)            (THIS_ DWORD dwPreset) PURE;
+    STDMETHOD(GetPreset)            (THIS_ LPDWORD pdwPreset) PURE;
+    STDMETHOD(SetQuality)           (THIS_ LONG lQuality) PURE;
+    STDMETHOD(GetQuality)           (THIS_ LONG *plQuality) PURE;
+};
+
+#define IDirectSoundFXI3DL2Reverb_QueryInterface(p,a,b)     IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXI3DL2Reverb_AddRef(p)                 IUnknown_AddRef(p)
+#define IDirectSoundFXI3DL2Reverb_Release(p)                IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXI3DL2Reverb_SetAllParameters(p,a)     (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXI3DL2Reverb_GetAllParameters(p,a)     (p)->lpVtbl->GetAllParameters(p,a)
+#define IDirectSoundFXI3DL2Reverb_SetPreset(p,a)            (p)->lpVtbl->SetPreset(p,a)
+#define IDirectSoundFXI3DL2Reverb_GetPreset(p,a)            (p)->lpVtbl->GetPreset(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXI3DL2Reverb_SetAllParameters(p,a)     (p)->SetAllParameters(a)
+#define IDirectSoundFXI3DL2Reverb_GetAllParameters(p,a)     (p)->GetAllParameters(a)
+#define IDirectSoundFXI3DL2Reverb_SetPreset(p,a)            (p)->SetPreset(a)
+#define IDirectSoundFXI3DL2Reverb_GetPreset(p,a)            (p)->GetPreset(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+
+//
+// IDirectSoundFXWavesReverb
+//
+
+DEFINE_GUID(IID_IDirectSoundFXWavesReverb,0x46858c3a,0x0dc6,0x45e3,0xb7,0x60,0xd4,0xee,0xf1,0x6c,0xb3,0x25);
+
+typedef struct _DSFXWavesReverb
+{
+    FLOAT   fInGain;                // [-96.0,0.0]            default: 0.0 dB
+    FLOAT   fReverbMix;             // [-96.0,0.0]            default: 0.0 db
+    FLOAT   fReverbTime;            // [0.001,3000.0]         default: 1000.0 ms
+    FLOAT   fHighFreqRTRatio;       // [0.001,0.999]          default: 0.001
+} DSFXWavesReverb, *LPDSFXWavesReverb;
+
+typedef const DSFXWavesReverb *LPCDSFXWavesReverb;
+
+#define DSFX_WAVESREVERB_INGAIN_MIN                 -96.0f
+#define DSFX_WAVESREVERB_INGAIN_MAX                 0.0f
+#define DSFX_WAVESREVERB_INGAIN_DEFAULT             0.0f
+#define DSFX_WAVESREVERB_REVERBMIX_MIN              -96.0f
+#define DSFX_WAVESREVERB_REVERBMIX_MAX              0.0f
+#define DSFX_WAVESREVERB_REVERBMIX_DEFAULT          0.0f
+#define DSFX_WAVESREVERB_REVERBTIME_MIN             0.001f
+#define DSFX_WAVESREVERB_REVERBTIME_MAX             3000.0f
+#define DSFX_WAVESREVERB_REVERBTIME_DEFAULT         1000.0f
+#define DSFX_WAVESREVERB_HIGHFREQRTRATIO_MIN        0.001f
+#define DSFX_WAVESREVERB_HIGHFREQRTRATIO_MAX        0.999f
+#define DSFX_WAVESREVERB_HIGHFREQRTRATIO_DEFAULT    0.001f
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFXWavesReverb
+
+DECLARE_INTERFACE_(IDirectSoundFXWavesReverb, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundFXWavesReverb methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSFXWavesReverb pcDsFxWavesReverb) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSFXWavesReverb pDsFxWavesReverb) PURE;
+};
+
+#define IDirectSoundFXWavesReverb_QueryInterface(p,a,b)     IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFXWavesReverb_AddRef(p)                 IUnknown_AddRef(p)
+#define IDirectSoundFXWavesReverb_Release(p)                IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXWavesReverb_SetAllParameters(p,a)     (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundFXWavesReverb_GetAllParameters(p,a)     (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFXWavesReverb_SetAllParameters(p,a)     (p)->SetAllParameters(a)
+#define IDirectSoundFXWavesReverb_GetAllParameters(p,a)     (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+//
+// IDirectSoundCaptureFXAec
+//
+
+DEFINE_GUID(IID_IDirectSoundCaptureFXAec, 0x174d3eb9, 0x6696, 0x4fac, 0xa4, 0x6c, 0xa0, 0xac, 0x7b, 0xc9, 0xe2, 0xf);
+
+typedef struct _DSCFXAec
+{
+    BOOL    fEnable;
+    BOOL    fReset;
+} DSCFXAec, *LPDSCFXAec;
+
+typedef const DSCFXAec *LPCDSCFXAec;
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundCaptureFXAec
+
+DECLARE_INTERFACE_(IDirectSoundCaptureFXAec, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundCaptureFXAec methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSCFXAec pDscFxAec) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSCFXAec pDscFxAec) PURE;
+};
+
+#define IDirectSoundCaptureFXAec_QueryInterface(p,a,b)     IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundCaptureFXAec_AddRef(p)                 IUnknown_AddRef(p)
+#define IDirectSoundCaptureFXAec_Release(p)                IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureFXAec_SetAllParameters(p,a)     (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundCaptureFXAec_GetAllParameters(p,a)     (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureFXAec_SetAllParameters(p,a)     (p)->SetAllParameters(a)
+#define IDirectSoundCaptureFXAec_GetAllParameters(p,a)     (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+
+//
+// IDirectSoundCaptureFXNoiseSuppress
+//
+
+DEFINE_GUID(IID_IDirectSoundCaptureFXNoiseSuppress, 0xed311e41, 0xfbae, 0x4175, 0x96, 0x25, 0xcd, 0x8, 0x54, 0xf6, 0x93, 0xca);
+
+typedef struct _DSCFXNoiseSuppress
+{
+    BOOL    fEnable;
+    BOOL    fReset;
+} DSCFXNoiseSuppress, *LPDSCFXNoiseSuppress;
+
+typedef const DSCFXNoiseSuppress *LPCDSCFXNoiseSuppress;
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundCaptureFXNoiseSuppress
+
+DECLARE_INTERFACE_(IDirectSoundCaptureFXNoiseSuppress, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)       (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)        (THIS) PURE;
+    STDMETHOD_(ULONG,Release)       (THIS) PURE;
+
+    // IDirectSoundCaptureFXNoiseSuppress methods
+    STDMETHOD(SetAllParameters)     (THIS_ LPCDSCFXNoiseSuppress pcDscFxNoiseSuppress) PURE;
+    STDMETHOD(GetAllParameters)     (THIS_ LPDSCFXNoiseSuppress pDscFxNoiseSuppress) PURE;
+};
+
+#define IDirectSoundCaptureFXNoiseSuppress_QueryInterface(p,a,b)     IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundCaptureFXNoiseSuppress_AddRef(p)                 IUnknown_AddRef(p)
+#define IDirectSoundCaptureFXNoiseSuppress_Release(p)                IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureFXNoiseSuppress_SetAllParameters(p,a)     (p)->lpVtbl->SetAllParameters(p,a)
+#define IDirectSoundCaptureFXNoiseSuppress_GetAllParameters(p,a)     (p)->lpVtbl->GetAllParameters(p,a)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundCaptureFXNoiseSuppress_SetAllParameters(p,a)     (p)->SetAllParameters(a)
+#define IDirectSoundCaptureFXNoiseSuppress_GetAllParameters(p,a)     (p)->GetAllParameters(a)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+
+//
+// IDirectSoundFullDuplex
+//
+
+#ifndef _IDirectSoundFullDuplex_
+#define _IDirectSoundFullDuplex_
+
+#ifdef __cplusplus
+// 'struct' not 'class' per the way DECLARE_INTERFACE_ is defined
+struct IDirectSoundFullDuplex;
+#endif // __cplusplus
+
+typedef struct IDirectSoundFullDuplex *LPDIRECTSOUNDFULLDUPLEX;
+
+DEFINE_GUID(IID_IDirectSoundFullDuplex, 0xedcb4c7a, 0xdaab, 0x4216, 0xa4, 0x2e, 0x6c, 0x50, 0x59, 0x6d, 0xdc, 0x1d);
+
+#undef INTERFACE
+#define INTERFACE IDirectSoundFullDuplex
+
+DECLARE_INTERFACE_(IDirectSoundFullDuplex, IUnknown)
+{
+    // IUnknown methods
+    STDMETHOD(QueryInterface)   (THIS_ REFIID, LPVOID *) PURE;
+    STDMETHOD_(ULONG,AddRef)    (THIS) PURE;
+    STDMETHOD_(ULONG,Release)   (THIS) PURE;
+
+    // IDirectSoundFullDuplex methods 
+    STDMETHOD(Initialize)     (THIS_ LPCGUID pCaptureGuid, LPCGUID pRenderGuid, LPCDSCBUFFERDESC lpDscBufferDesc, LPCDSBUFFERDESC lpDsBufferDesc, HWND hWnd, DWORD dwLevel, LPLPDIRECTSOUNDCAPTUREBUFFER8 lplpDirectSoundCaptureBuffer8, LPLPDIRECTSOUNDBUFFER8 lplpDirectSoundBuffer8) PURE;
+};
+
+#define IDirectSoundFullDuplex_QueryInterface(p,a,b)    IUnknown_QueryInterface(p,a,b)
+#define IDirectSoundFullDuplex_AddRef(p)                IUnknown_AddRef(p)
+#define IDirectSoundFullDuplex_Release(p)               IUnknown_Release(p)
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFullDuplex_Initialize(p,a,b,c,d,e,f,g,h)     (p)->lpVtbl->Initialize(p,a,b,c,d,e,f,g,h)
+#else // !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirectSoundFullDuplex_Initialize(p,a,b,c,d,e,f,g,h)     (p)->Initialize(a,b,c,d,e,f,g,h)
+#endif // !defined(__cplusplus) || defined(CINTERFACE)
+
+#endif // _IDirectSoundFullDuplex_
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+//
+// Return Codes
+//
+
+// The function completed successfully
+#define DS_OK                           S_OK
+
+// The call succeeded, but we had to substitute the 3D algorithm
+#define DS_NO_VIRTUALIZATION            MAKE_HRESULT(0, _FACDS, 10)
+
+// The call succeeded, but not all of the optional effects were obtained.
+#define DS_INCOMPLETE                   MAKE_HRESULT(0, _FACDS, 20)
+
+// The call failed because resources (such as a priority level)
+// were already being used by another caller
+#define DSERR_ALLOCATED                 MAKE_DSHRESULT(10)
+
+// The control (vol, pan, etc.) requested by the caller is not available
+#define DSERR_CONTROLUNAVAIL            MAKE_DSHRESULT(30)
+
+// An invalid parameter was passed to the returning function
+#define DSERR_INVALIDPARAM              E_INVALIDARG
+
+// This call is not valid for the current state of this object
+#define DSERR_INVALIDCALL               MAKE_DSHRESULT(50)
+
+// An undetermined error occurred inside the DirectSound subsystem
+#define DSERR_GENERIC                   E_FAIL
+
+// The caller does not have the priority level required for the function to
+// succeed
+#define DSERR_PRIOLEVELNEEDED           MAKE_DSHRESULT(70)
+
+// Not enough free memory is available to complete the operation
+#define DSERR_OUTOFMEMORY               E_OUTOFMEMORY
+
+// The specified WAVE format is not supported
+#define DSERR_BADFORMAT                 MAKE_DSHRESULT(100)
+
+// The function called is not supported at this time
+#define DSERR_UNSUPPORTED               E_NOTIMPL
+
+// No sound driver is available for use
+#define DSERR_NODRIVER                  MAKE_DSHRESULT(120)
+
+// This object is already initialized
+#define DSERR_ALREADYINITIALIZED        MAKE_DSHRESULT(130)
+
+// This object does not support aggregation
+#define DSERR_NOAGGREGATION             CLASS_E_NOAGGREGATION
+
+// The buffer memory has been lost, and must be restored
+#define DSERR_BUFFERLOST                MAKE_DSHRESULT(150)
+
+// Another app has a higher priority level, preventing this call from
+// succeeding
+#define DSERR_OTHERAPPHASPRIO           MAKE_DSHRESULT(160)
+
+// This object has not been initialized
+#define DSERR_UNINITIALIZED             MAKE_DSHRESULT(170)
+
+// The requested COM interface is not available
+#define DSERR_NOINTERFACE               E_NOINTERFACE
+
+// Access is denied
+#define DSERR_ACCESSDENIED              E_ACCESSDENIED
+
+// Tried to create a DSBCAPS_CTRLFX buffer shorter than DSBSIZE_FX_MIN milliseconds
+#define DSERR_BUFFERTOOSMALL            MAKE_DSHRESULT(180)
+
+// Attempt to use DirectSound 8 functionality on an older DirectSound object
+#define DSERR_DS8_REQUIRED              MAKE_DSHRESULT(190)
+
+// A circular loop of send effects was detected
+#define DSERR_SENDLOOP                  MAKE_DSHRESULT(200)
+
+// The GUID specified in an audiopath file does not match a valid MIXIN buffer
+#define DSERR_BADSENDBUFFERGUID         MAKE_DSHRESULT(210)
+
+// The object requested was not found (numerically equal to DMUS_E_NOT_FOUND)
+#define DSERR_OBJECTNOTFOUND            MAKE_DSHRESULT(4449)
+
+//
+// Flags
+//
+
+#define DSCAPS_PRIMARYMONO          0x00000001
+#define DSCAPS_PRIMARYSTEREO        0x00000002
+#define DSCAPS_PRIMARY8BIT          0x00000004
+#define DSCAPS_PRIMARY16BIT         0x00000008
+#define DSCAPS_CONTINUOUSRATE       0x00000010
+#define DSCAPS_EMULDRIVER           0x00000020
+#define DSCAPS_CERTIFIED            0x00000040
+#define DSCAPS_SECONDARYMONO        0x00000100
+#define DSCAPS_SECONDARYSTEREO      0x00000200
+#define DSCAPS_SECONDARY8BIT        0x00000400
+#define DSCAPS_SECONDARY16BIT       0x00000800
+
+#define DSSCL_NORMAL                0x00000001
+#define DSSCL_PRIORITY              0x00000002
+#define DSSCL_EXCLUSIVE             0x00000003
+#define DSSCL_WRITEPRIMARY          0x00000004
+
+#define DSSPEAKER_HEADPHONE         0x00000001
+#define DSSPEAKER_MONO              0x00000002
+#define DSSPEAKER_QUAD              0x00000003
+#define DSSPEAKER_STEREO            0x00000004
+#define DSSPEAKER_SURROUND          0x00000005
+#define DSSPEAKER_5POINT1           0x00000006
+
+#define DSSPEAKER_GEOMETRY_MIN      0x00000005  //   5 degrees
+#define DSSPEAKER_GEOMETRY_NARROW   0x0000000A  //  10 degrees
+#define DSSPEAKER_GEOMETRY_WIDE     0x00000014  //  20 degrees
+#define DSSPEAKER_GEOMETRY_MAX      0x000000B4  // 180 degrees
+
+#define DSSPEAKER_COMBINED(c, g)    ((DWORD)(((BYTE)(c)) | ((DWORD)((BYTE)(g))) << 16))
+#define DSSPEAKER_CONFIG(a)         ((BYTE)(a))
+#define DSSPEAKER_GEOMETRY(a)       ((BYTE)(((DWORD)(a) >> 16) & 0x00FF))
+
+#define DSBCAPS_PRIMARYBUFFER       0x00000001
+#define DSBCAPS_STATIC              0x00000002
+#define DSBCAPS_LOCHARDWARE         0x00000004
+#define DSBCAPS_LOCSOFTWARE         0x00000008
+#define DSBCAPS_CTRL3D              0x00000010
+#define DSBCAPS_CTRLFREQUENCY       0x00000020
+#define DSBCAPS_CTRLPAN             0x00000040
+#define DSBCAPS_CTRLVOLUME          0x00000080
+#define DSBCAPS_CTRLPOSITIONNOTIFY  0x00000100
+#define DSBCAPS_CTRLFX              0x00000200
+#define DSBCAPS_STICKYFOCUS         0x00004000
+#define DSBCAPS_GLOBALFOCUS         0x00008000
+#define DSBCAPS_GETCURRENTPOSITION2 0x00010000
+#define DSBCAPS_MUTE3DATMAXDISTANCE 0x00020000
+#define DSBCAPS_LOCDEFER            0x00040000
+
+#define DSBPLAY_LOOPING             0x00000001
+#define DSBPLAY_LOCHARDWARE         0x00000002
+#define DSBPLAY_LOCSOFTWARE         0x00000004
+#define DSBPLAY_TERMINATEBY_TIME    0x00000008
+#define DSBPLAY_TERMINATEBY_DISTANCE    0x000000010
+#define DSBPLAY_TERMINATEBY_PRIORITY    0x000000020
+
+#define DSBSTATUS_PLAYING           0x00000001
+#define DSBSTATUS_BUFFERLOST        0x00000002
+#define DSBSTATUS_LOOPING           0x00000004
+#define DSBSTATUS_LOCHARDWARE       0x00000008
+#define DSBSTATUS_LOCSOFTWARE       0x00000010
+#define DSBSTATUS_TERMINATED        0x00000020
+
+#define DSBLOCK_FROMWRITECURSOR     0x00000001
+#define DSBLOCK_ENTIREBUFFER        0x00000002
+
+#define DSBFREQUENCY_MIN            100
+#define DSBFREQUENCY_MAX            100000
+#define DSBFREQUENCY_ORIGINAL       0
+
+#define DSBPAN_LEFT                 -10000
+#define DSBPAN_CENTER               0
+#define DSBPAN_RIGHT                10000
+
+#define DSBVOLUME_MIN               -10000
+#define DSBVOLUME_MAX               0
+
+#define DSBSIZE_MIN                 4
+#define DSBSIZE_MAX                 0x0FFFFFFF
+#define DSBSIZE_FX_MIN              150  // NOTE: Milliseconds, not bytes
+
+#define DS3DMODE_NORMAL             0x00000000
+#define DS3DMODE_HEADRELATIVE       0x00000001
+#define DS3DMODE_DISABLE            0x00000002
+
+#define DS3D_IMMEDIATE              0x00000000
+#define DS3D_DEFERRED               0x00000001
+
+#define DS3D_MINDISTANCEFACTOR      FLT_MIN
+#define DS3D_MAXDISTANCEFACTOR      FLT_MAX
+#define DS3D_DEFAULTDISTANCEFACTOR  1.0f
+
+#define DS3D_MINROLLOFFFACTOR       0.0f
+#define DS3D_MAXROLLOFFFACTOR       10.0f
+#define DS3D_DEFAULTROLLOFFFACTOR   1.0f
+
+#define DS3D_MINDOPPLERFACTOR       0.0f
+#define DS3D_MAXDOPPLERFACTOR       10.0f
+#define DS3D_DEFAULTDOPPLERFACTOR   1.0f
+
+#define DS3D_DEFAULTMINDISTANCE     1.0f
+#define DS3D_DEFAULTMAXDISTANCE     1000000000.0f
+
+#define DS3D_MINCONEANGLE           0
+#define DS3D_MAXCONEANGLE           360
+#define DS3D_DEFAULTCONEANGLE       360
+
+#define DS3D_DEFAULTCONEOUTSIDEVOLUME DSBVOLUME_MAX
+
+// IDirectSoundCapture attributes
+
+#define DSCCAPS_EMULDRIVER          DSCAPS_EMULDRIVER
+#define DSCCAPS_CERTIFIED           DSCAPS_CERTIFIED
+
+// IDirectSoundCaptureBuffer attributes
+
+#define DSCBCAPS_WAVEMAPPED         0x80000000
+
+#if DIRECTSOUND_VERSION >= 0x0800
+#define DSCBCAPS_CTRLFX             0x00000200
+#endif
+
+
+#define DSCBLOCK_ENTIREBUFFER       0x00000001
+
+#define DSCBSTATUS_CAPTURING        0x00000001
+#define DSCBSTATUS_LOOPING          0x00000002
+
+#define DSCBSTART_LOOPING           0x00000001
+
+#define DSBPN_OFFSETSTOP            0xFFFFFFFF
+
+#define DS_CERTIFIED                0x00000000
+#define DS_UNCERTIFIED              0x00000001
+
+// Dsound SYSTEM resource constants
+// Matches the KSAUDIO_CPU_RESOURCES_xxx_HOST_CPU values defined 
+// in ksmedia.h.
+#define DS_SYSTEM_RESOURCES_NO_HOST_RESOURCES  0x00000000
+#define DS_SYSTEM_RESOURCES_ALL_HOST_RESOURCES 0x7FFFFFFF
+#define DS_SYSTEM_RESOURCES_UNDEFINED          0x80000000
+
+
+//
+// I3DL2 Material Presets
+//
+
+enum
+{
+    DSFX_I3DL2_MATERIAL_PRESET_SINGLEWINDOW,
+    DSFX_I3DL2_MATERIAL_PRESET_DOUBLEWINDOW,
+    DSFX_I3DL2_MATERIAL_PRESET_THINDOOR,
+    DSFX_I3DL2_MATERIAL_PRESET_THICKDOOR,
+    DSFX_I3DL2_MATERIAL_PRESET_WOODWALL,
+    DSFX_I3DL2_MATERIAL_PRESET_BRICKWALL,
+    DSFX_I3DL2_MATERIAL_PRESET_STONEWALL,
+    DSFX_I3DL2_MATERIAL_PRESET_CURTAIN
+};
+
+#define I3DL2_MATERIAL_PRESET_SINGLEWINDOW    -2800,0.71f
+#define I3DL2_MATERIAL_PRESET_DOUBLEWINDOW    -5000,0.40f
+#define I3DL2_MATERIAL_PRESET_THINDOOR        -1800,0.66f
+#define I3DL2_MATERIAL_PRESET_THICKDOOR       -4400,0.64f
+#define I3DL2_MATERIAL_PRESET_WOODWALL        -4000,0.50f
+#define I3DL2_MATERIAL_PRESET_BRICKWALL       -5000,0.60f
+#define I3DL2_MATERIAL_PRESET_STONEWALL       -6000,0.68f
+#define I3DL2_MATERIAL_PRESET_CURTAIN         -1200,0.15f
+
+
+enum
+{
+    DSFX_I3DL2_ENVIRONMENT_PRESET_DEFAULT,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_GENERIC,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_PADDEDCELL,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_ROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_BATHROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_LIVINGROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_STONEROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_AUDITORIUM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_CONCERTHALL,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_CAVE,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_ARENA,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_HANGAR,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_CARPETEDHALLWAY,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_HALLWAY,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_STONECORRIDOR,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_ALLEY,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_FOREST,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_CITY,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_MOUNTAINS,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_QUARRY,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_PLAIN,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_PARKINGLOT,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_SEWERPIPE,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_UNDERWATER,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_SMALLROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_MEDIUMROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_LARGEROOM,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_MEDIUMHALL,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_LARGEHALL,
+    DSFX_I3DL2_ENVIRONMENT_PRESET_PLATE
+};
+
+//
+// I3DL2 Reverberation Presets Values
+//
+
+#define I3DL2_ENVIRONMENT_PRESET_DEFAULT         -1000, -100, 0.0f, 1.49f, 0.83f, -2602, 0.007f,   200, 0.011f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_GENERIC         -1000, -100, 0.0f, 1.49f, 0.83f, -2602, 0.007f,   200, 0.011f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_PADDEDCELL      -1000,-6000, 0.0f, 0.17f, 0.10f, -1204, 0.001f,   207, 0.002f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_ROOM            -1000, -454, 0.0f, 0.40f, 0.83f, -1646, 0.002f,    53, 0.003f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_BATHROOM        -1000,-1200, 0.0f, 1.49f, 0.54f,  -370, 0.007f,  1030, 0.011f, 100.0f,  60.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_LIVINGROOM      -1000,-6000, 0.0f, 0.50f, 0.10f, -1376, 0.003f, -1104, 0.004f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_STONEROOM       -1000, -300, 0.0f, 2.31f, 0.64f,  -711, 0.012f,    83, 0.017f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_AUDITORIUM      -1000, -476, 0.0f, 4.32f, 0.59f,  -789, 0.020f,  -289, 0.030f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_CONCERTHALL     -1000, -500, 0.0f, 3.92f, 0.70f, -1230, 0.020f,    -2, 0.029f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_CAVE            -1000,    0, 0.0f, 2.91f, 1.30f,  -602, 0.015f,  -302, 0.022f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_ARENA           -1000, -698, 0.0f, 7.24f, 0.33f, -1166, 0.020f,    16, 0.030f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_HANGAR          -1000,-1000, 0.0f,10.05f, 0.23f,  -602, 0.020f,   198, 0.030f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_CARPETEDHALLWAY -1000,-4000, 0.0f, 0.30f, 0.10f, -1831, 0.002f, -1630, 0.030f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_HALLWAY         -1000, -300, 0.0f, 1.49f, 0.59f, -1219, 0.007f,   441, 0.011f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_STONECORRIDOR   -1000, -237, 0.0f, 2.70f, 0.79f, -1214, 0.013f,   395, 0.020f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_ALLEY           -1000, -270, 0.0f, 1.49f, 0.86f, -1204, 0.007f,    -4, 0.011f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_FOREST          -1000,-3300, 0.0f, 1.49f, 0.54f, -2560, 0.162f,  -613, 0.088f,  79.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_CITY            -1000, -800, 0.0f, 1.49f, 0.67f, -2273, 0.007f, -2217, 0.011f,  50.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_MOUNTAINS       -1000,-2500, 0.0f, 1.49f, 0.21f, -2780, 0.300f, -2014, 0.100f,  27.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_QUARRY          -1000,-1000, 0.0f, 1.49f, 0.83f,-10000, 0.061f,   500, 0.025f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_PLAIN           -1000,-2000, 0.0f, 1.49f, 0.50f, -2466, 0.179f, -2514, 0.100f,  21.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_PARKINGLOT      -1000,    0, 0.0f, 1.65f, 1.50f, -1363, 0.008f, -1153, 0.012f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_SEWERPIPE       -1000,-1000, 0.0f, 2.81f, 0.14f,   429, 0.014f,   648, 0.021f,  80.0f,  60.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_UNDERWATER      -1000,-4000, 0.0f, 1.49f, 0.10f,  -449, 0.007f,  1700, 0.011f, 100.0f, 100.0f, 5000.0f
+
+//
+// Examples simulating 'musical' reverb presets
+//
+// Name       Decay time   Description
+// Small Room    1.1s      A small size room with a length of 5m or so.
+// Medium Room   1.3s      A medium size room with a length of 10m or so.
+// Large Room    1.5s      A large size room suitable for live performances.
+// Medium Hall   1.8s      A medium size concert hall.
+// Large Hall    1.8s      A large size concert hall suitable for a full orchestra.
+// Plate         1.3s      A plate reverb simulation.
+//
+
+#define I3DL2_ENVIRONMENT_PRESET_SMALLROOM       -1000, -600, 0.0f, 1.10f, 0.83f,  -400, 0.005f,   500, 0.010f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_MEDIUMROOM      -1000, -600, 0.0f, 1.30f, 0.83f, -1000, 0.010f,  -200, 0.020f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_LARGEROOM       -1000, -600, 0.0f, 1.50f, 0.83f, -1600, 0.020f, -1000, 0.040f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_MEDIUMHALL      -1000, -600, 0.0f, 1.80f, 0.70f, -1300, 0.015f,  -800, 0.030f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_LARGEHALL       -1000, -600, 0.0f, 1.80f, 0.70f, -2000, 0.030f, -1400, 0.060f, 100.0f, 100.0f, 5000.0f
+#define I3DL2_ENVIRONMENT_PRESET_PLATE           -1000, -200, 0.0f, 1.30f, 0.90f,     0, 0.002f,     0, 0.010f, 100.0f,  75.0f, 5000.0f
+
+//
+// DirectSound3D Algorithms
+//
+
+// Default DirectSound3D algorithm {00000000-0000-0000-0000-000000000000}
+#define DS3DALG_DEFAULT GUID_NULL
+
+// No virtualization (Pan3D) {C241333F-1C1B-11d2-94F5-00C04FC28ACA}
+DEFINE_GUID(DS3DALG_NO_VIRTUALIZATION, 0xc241333f, 0x1c1b, 0x11d2, 0x94, 0xf5, 0x0, 0xc0, 0x4f, 0xc2, 0x8a, 0xca);
+
+// High-quality HRTF algorithm {C2413340-1C1B-11d2-94F5-00C04FC28ACA}
+DEFINE_GUID(DS3DALG_HRTF_FULL, 0xc2413340, 0x1c1b, 0x11d2, 0x94, 0xf5, 0x0, 0xc0, 0x4f, 0xc2, 0x8a, 0xca);
+
+// Lower-quality HRTF algorithm {C2413342-1C1B-11d2-94F5-00C04FC28ACA}
+DEFINE_GUID(DS3DALG_HRTF_LIGHT, 0xc2413342, 0x1c1b, 0x11d2, 0x94, 0xf5, 0x0, 0xc0, 0x4f, 0xc2, 0x8a, 0xca);
+
+
+#if DIRECTSOUND_VERSION >= 0x0800
+
+//
+// DirectSound Internal Effect Algorithms
+//
+
+
+// Gargle {DAFD8210-5711-4B91-9FE3-F75B7AE279BF}
+DEFINE_GUID(GUID_DSFX_STANDARD_GARGLE, 0xdafd8210, 0x5711, 0x4b91, 0x9f, 0xe3, 0xf7, 0x5b, 0x7a, 0xe2, 0x79, 0xbf);
+
+// Chorus {EFE6629C-81F7-4281-BD91-C9D604A95AF6}
+DEFINE_GUID(GUID_DSFX_STANDARD_CHORUS, 0xefe6629c, 0x81f7, 0x4281, 0xbd, 0x91, 0xc9, 0xd6, 0x04, 0xa9, 0x5a, 0xf6);
+
+// Flanger {EFCA3D92-DFD8-4672-A603-7420894BAD98}
+DEFINE_GUID(GUID_DSFX_STANDARD_FLANGER, 0xefca3d92, 0xdfd8, 0x4672, 0xa6, 0x03, 0x74, 0x20, 0x89, 0x4b, 0xad, 0x98);
+
+// Echo/Delay {EF3E932C-D40B-4F51-8CCF-3F98F1B29D5D}
+DEFINE_GUID(GUID_DSFX_STANDARD_ECHO, 0xef3e932c, 0xd40b, 0x4f51, 0x8c, 0xcf, 0x3f, 0x98, 0xf1, 0xb2, 0x9d, 0x5d);
+
+// Distortion {EF114C90-CD1D-484E-96E5-09CFAF912A21}
+DEFINE_GUID(GUID_DSFX_STANDARD_DISTORTION, 0xef114c90, 0xcd1d, 0x484e, 0x96, 0xe5, 0x09, 0xcf, 0xaf, 0x91, 0x2a, 0x21);
+
+// Compressor/Limiter {EF011F79-4000-406D-87AF-BFFB3FC39D57}
+DEFINE_GUID(GUID_DSFX_STANDARD_COMPRESSOR, 0xef011f79, 0x4000, 0x406d, 0x87, 0xaf, 0xbf, 0xfb, 0x3f, 0xc3, 0x9d, 0x57);
+
+// Parametric Equalization {120CED89-3BF4-4173-A132-3CB406CF3231}
+DEFINE_GUID(GUID_DSFX_STANDARD_PARAMEQ, 0x120ced89, 0x3bf4, 0x4173, 0xa1, 0x32, 0x3c, 0xb4, 0x06, 0xcf, 0x32, 0x31);
+
+
+// I3DL2 Environmental Reverberation: Reverb (Listener) Effect {EF985E71-D5C7-42D4-BA4D-2D073E2E96F4}
+DEFINE_GUID(GUID_DSFX_STANDARD_I3DL2REVERB, 0xef985e71, 0xd5c7, 0x42d4, 0xba, 0x4d, 0x2d, 0x07, 0x3e, 0x2e, 0x96, 0xf4);
+
+// Waves Reverberation {87FC0268-9A55-4360-95AA-004A1D9DE26C}
+DEFINE_GUID(GUID_DSFX_WAVES_REVERB, 0x87fc0268, 0x9a55, 0x4360, 0x95, 0xaa, 0x00, 0x4a, 0x1d, 0x9d, 0xe2, 0x6c);
+
+//
+// DirectSound Capture Effect Algorithms
+//
+
+
+// Acoustic Echo Canceller {BF963D80-C559-11D0-8A2B-00A0C9255AC1}
+// Matches KSNODETYPE_ACOUSTIC_ECHO_CANCEL in ksmedia.h
+DEFINE_GUID(GUID_DSCFX_CLASS_AEC, 0xBF963D80L, 0xC559, 0x11D0, 0x8A, 0x2B, 0x00, 0xA0, 0xC9, 0x25, 0x5A, 0xC1);
+
+// Microsoft AEC {CDEBB919-379A-488a-8765-F53CFD36DE40}
+DEFINE_GUID(GUID_DSCFX_MS_AEC, 0xcdebb919, 0x379a, 0x488a, 0x87, 0x65, 0xf5, 0x3c, 0xfd, 0x36, 0xde, 0x40);
+
+// System AEC {1C22C56D-9879-4f5b-A389-27996DDC2810}
+DEFINE_GUID(GUID_DSCFX_SYSTEM_AEC, 0x1c22c56d, 0x9879, 0x4f5b, 0xa3, 0x89, 0x27, 0x99, 0x6d, 0xdc, 0x28, 0x10);
+
+// Noise Supression {E07F903F-62FD-4e60-8CDD-DEA7236665B5}
+// Matches KSNODETYPE_NOISE_SUPPRESS in post Windows ME DDK's ksmedia.h
+DEFINE_GUID(GUID_DSCFX_CLASS_NS, 0xe07f903f, 0x62fd, 0x4e60, 0x8c, 0xdd, 0xde, 0xa7, 0x23, 0x66, 0x65, 0xb5);
+
+// Microsoft Noise Suppresion {11C5C73B-66E9-4ba1-A0BA-E814C6EED92D}
+DEFINE_GUID(GUID_DSCFX_MS_NS, 0x11c5c73b, 0x66e9, 0x4ba1, 0xa0, 0xba, 0xe8, 0x14, 0xc6, 0xee, 0xd9, 0x2d);
+
+// System Noise Suppresion {5AB0882E-7274-4516-877D-4EEE99BA4FD0}
+DEFINE_GUID(GUID_DSCFX_SYSTEM_NS, 0x5ab0882e, 0x7274, 0x4516, 0x87, 0x7d, 0x4e, 0xee, 0x99, 0xba, 0x4f, 0xd0);
+
+
+#endif // DIRECTSOUND_VERSION >= 0x0800
+
+#endif // __DSOUND_INCLUDED__
+
+
+
+#ifdef __cplusplus
+};
+#endif // __cplusplus
+
+

--- a/gccbuild/dx_mingw/xaudio2.h
+++ b/gccbuild/dx_mingw/xaudio2.h
@@ -1,0 +1,1275 @@
+/**************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * File:    xaudio2.h
+ * Content: Declarations for the XAudio2 game audio API.
+ *
+ **************************************************************************/
+
+#ifndef __XAUDIO2_INCLUDED__
+#define __XAUDIO2_INCLUDED__
+
+
+/**************************************************************************
+ *
+ * XAudio2 COM object class and interface IDs.
+ *
+ **************************************************************************/
+
+#include <comdecl.h>        // For DEFINE_CLSID and DEFINE_IID
+
+// XAudio 2.0 (March 2008 SDK)
+//DEFINE_CLSID(XAudio2, fac23f48, 31f5, 45a8, b4, 9b, 52, 25, d6, 14, 01, aa);
+//DEFINE_CLSID(XAudio2_Debug, fac23f48, 31f5, 45a8, b4, 9b, 52, 25, d6, 14, 01, db);
+
+// XAudio 2.1 (June 2008 SDK)
+//DEFINE_CLSID(XAudio2, e21a7345, eb21, 468e, be, 50, 80, 4d, b9, 7c, f7, 08);
+//DEFINE_CLSID(XAudio2_Debug, f7a76c21, 53d4, 46bb, ac, 53, 8b, 45, 9c, ae, 46, bd);
+
+// XAudio 2.2 (August 2008 SDK)
+//DEFINE_CLSID(XAudio2, b802058a, 464a, 42db, bc, 10, b6, 50, d6, f2, 58, 6a);
+//DEFINE_CLSID(XAudio2_Debug, 97dfb7e7, 5161, 4015, 87, a9, c7, 9e, 6a, 19, 52, cc);
+
+// XAudio 2.3 (November 2008 SDK)
+//DEFINE_CLSID(XAudio2, 4c5e637a, 16c7, 4de3, 9c, 46, 5e, d2, 21, 81, 96, 2d);
+//DEFINE_CLSID(XAudio2_Debug, ef0aa05d, 8075, 4e5d, be, ad, 45, be, 0c, 3c, cb, b3);
+
+// XAudio 2.4 (March 2009 SDK)
+//DEFINE_CLSID(XAudio2, 03219e78, 5bc3, 44d1, b9, 2e, f6, 3d, 89, cc, 65, 26);
+//DEFINE_CLSID(XAudio2_Debug, 4256535c, 1ea4, 4d4b, 8a, d5, f9, db, 76, 2e, ca, 9e);
+
+// XAudio 2.5 (August 2009 SDK)
+DEFINE_CLSID(XAudio2, 4c9b6dde, 6809, 46e6, a2, 78, 9b, 6a, 97, 58, 86, 70);
+DEFINE_CLSID(XAudio2_Debug, 715bdd1a, aa82, 436b, b0, fa, 6a, ce, a3, 9b, d0, a1);
+
+DEFINE_IID(IXAudio2, 8bcf1f58, 9fe7, 4583, 8a, c6, e2, ad, c4, 65, c8, bb);
+
+
+// Ignore the rest of this header if only the GUID definitions were requested
+#ifndef GUID_DEFS_ONLY
+
+#ifdef _XBOX
+    #include <xobjbase.h>   // Xbox COM declarations (IUnknown, etc)
+#else
+    #include <objbase.h>    // Windows COM declarations
+#endif
+
+#include <sal.h>            // Markers for documenting API semantics
+#include <audiodefs.h>      // Basic audio data types and constants
+#include <xma2defs.h>       // Data types and constants for XMA2 audio
+
+// All structures defined in this file use tight field packing
+#pragma pack(push, 1)
+
+
+/**************************************************************************
+ *
+ * XAudio2 constants, flags and error codes.
+ *
+ **************************************************************************/
+
+// Numeric boundary values
+#define XAUDIO2_MAX_BUFFER_BYTES        0x80000000    // Maximum bytes allowed in a source buffer
+#define XAUDIO2_MAX_QUEUED_BUFFERS      64            // Maximum buffers allowed in a voice queue
+#define XAUDIO2_MAX_BUFFERS_SYSTEM      2             // Maximum buffers allowed for system threads (Xbox 360 only)
+#define XAUDIO2_MAX_AUDIO_CHANNELS      64            // Maximum channels in an audio stream
+#define XAUDIO2_MIN_SAMPLE_RATE         1000          // Minimum audio sample rate supported
+#define XAUDIO2_MAX_SAMPLE_RATE         200000        // Maximum audio sample rate supported
+#define XAUDIO2_MAX_VOLUME_LEVEL        16777216.0f   // Maximum acceptable volume level (2^24)
+#define XAUDIO2_MIN_FREQ_RATIO          (1/1024.0f)   // Minimum SetFrequencyRatio argument
+#define XAUDIO2_MAX_FREQ_RATIO          1024.0f       // Maximum MaxFrequencyRatio argument
+#define XAUDIO2_DEFAULT_FREQ_RATIO      2.0f          // Default MaxFrequencyRatio argument
+#define XAUDIO2_MAX_FILTER_ONEOVERQ     1.5f          // Maximum XAUDIO2_FILTER_PARAMETERS.OneOverQ
+#define XAUDIO2_MAX_FILTER_FREQUENCY    1.0f          // Maximum XAUDIO2_FILTER_PARAMETERS.Frequency
+#define XAUDIO2_MAX_LOOP_COUNT          254           // Maximum non-infinite XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_MAX_INSTANCES           8             // Maximum simultaneous XAudio2 objects on Xbox 360
+
+// For XMA voices on Xbox 360 there is an additional restriction on the MaxFrequencyRatio
+// argument and the voice's sample rate: the product of these numbers cannot exceed 600000
+// for one-channel voices or 300000 for voices with more than one channel.
+#define XAUDIO2_MAX_RATIO_TIMES_RATE_XMA_MONO         600000
+#define XAUDIO2_MAX_RATIO_TIMES_RATE_XMA_MULTICHANNEL 300000
+
+// Numeric values with special meanings
+#define XAUDIO2_COMMIT_NOW              0             // Used as an OperationSet argument
+#define XAUDIO2_COMMIT_ALL              0             // Used in IXAudio2::CommitChanges
+#define XAUDIO2_INVALID_OPSET           (UINT32)(-1)  // Not allowed for OperationSet arguments
+#define XAUDIO2_NO_LOOP_REGION          0             // Used in XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_LOOP_INFINITE           255           // Used in XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_DEFAULT_CHANNELS        0             // Used in CreateMasteringVoice
+#define XAUDIO2_DEFAULT_SAMPLERATE      0             // Used in CreateMasteringVoice
+
+// Flags
+#define XAUDIO2_DEBUG_ENGINE            0x0001        // Used in XAudio2Create on Windows only
+#define XAUDIO2_VOICE_NOPITCH           0x0002        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_VOICE_NOSRC             0x0004        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_VOICE_USEFILTER         0x0008        // Used in IXAudio2::CreateSource/SubmixVoice
+#define XAUDIO2_VOICE_MUSIC             0x0010        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_PLAY_TAILS              0x0020        // Used in IXAudio2SourceVoice::Stop
+#define XAUDIO2_END_OF_STREAM           0x0040        // Used in XAUDIO2_BUFFER.Flags
+#define XAUDIO2_SEND_USEFILTER          0x0080        // Used in XAUDIO2_SEND_DESCRIPTOR.Flags
+
+// Default parameters for the built-in filter
+#define XAUDIO2_DEFAULT_FILTER_TYPE     LowPassFilter
+#define XAUDIO2_DEFAULT_FILTER_FREQUENCY XAUDIO2_MAX_FILTER_FREQUENCY
+#define XAUDIO2_DEFAULT_FILTER_ONEOVERQ 1.0f
+
+// Internal XAudio2 constants
+#ifdef _XBOX
+    #define XAUDIO2_QUANTUM_NUMERATOR   2             // On Xbox 360, XAudio2 processes audio
+    #define XAUDIO2_QUANTUM_DENOMINATOR 375           //  in 5.333ms chunks (= 2/375 seconds)
+#else
+    #define XAUDIO2_QUANTUM_NUMERATOR   1             // On Windows, XAudio2 processes audio
+    #define XAUDIO2_QUANTUM_DENOMINATOR 100           //  in 10ms chunks (= 1/100 seconds)
+#endif
+#define XAUDIO2_QUANTUM_MS (1000.0f * XAUDIO2_QUANTUM_NUMERATOR / XAUDIO2_QUANTUM_DENOMINATOR)
+
+// XAudio2 error codes
+#define FACILITY_XAUDIO2 0x896
+#define XAUDIO2_E_INVALID_CALL          0x88960001    // An API call or one of its arguments was illegal
+#define XAUDIO2_E_XMA_DECODER_ERROR     0x88960002    // The XMA hardware suffered an unrecoverable error
+#define XAUDIO2_E_XAPO_CREATION_FAILED  0x88960003    // XAudio2 failed to initialize an XAPO effect
+#define XAUDIO2_E_DEVICE_INVALIDATED    0x88960004    // An audio device became unusable (unplugged, etc)
+
+
+/**************************************************************************
+ *
+ * Forward declarations for the XAudio2 interfaces.
+ *
+ **************************************************************************/
+
+#ifdef __cplusplus
+    #define FWD_DECLARE(x) interface x
+#else
+    #define FWD_DECLARE(x) typedef interface x x
+#endif
+
+FWD_DECLARE(IXAudio2);
+FWD_DECLARE(IXAudio2Voice);
+FWD_DECLARE(IXAudio2SourceVoice);
+FWD_DECLARE(IXAudio2SubmixVoice);
+FWD_DECLARE(IXAudio2MasteringVoice);
+FWD_DECLARE(IXAudio2EngineCallback);
+FWD_DECLARE(IXAudio2VoiceCallback);
+
+
+/**************************************************************************
+ *
+ * XAudio2 structures and enumerations.
+ *
+ **************************************************************************/
+
+// Used in IXAudio2::Initialize
+#ifdef _XBOX
+    typedef enum XAUDIO2_XBOX_HWTHREAD_SPECIFIER
+    {
+        XboxThread0 = 0x01,
+        XboxThread1 = 0x02,
+        XboxThread2 = 0x04,
+        XboxThread3 = 0x08,
+        XboxThread4 = 0x10,
+        XboxThread5 = 0x20,
+        XAUDIO2_ANY_PROCESSOR = XboxThread4,
+        XAUDIO2_DEFAULT_PROCESSOR = XAUDIO2_ANY_PROCESSOR
+    } XAUDIO2_XBOX_HWTHREAD_SPECIFIER, XAUDIO2_PROCESSOR;
+#else
+    typedef enum XAUDIO2_WINDOWS_PROCESSOR_SPECIFIER
+    {
+        Processor1  = 0x00000001,
+        Processor2  = 0x00000002,
+        Processor3  = 0x00000004,
+        Processor4  = 0x00000008,
+        Processor5  = 0x00000010,
+        Processor6  = 0x00000020,
+        Processor7  = 0x00000040,
+        Processor8  = 0x00000080,
+        Processor9  = 0x00000100,
+        Processor10 = 0x00000200,
+        Processor11 = 0x00000400,
+        Processor12 = 0x00000800,
+        Processor13 = 0x00001000,
+        Processor14 = 0x00002000,
+        Processor15 = 0x00004000,
+        Processor16 = 0x00008000,
+        Processor17 = 0x00010000,
+        Processor18 = 0x00020000,
+        Processor19 = 0x00040000,
+        Processor20 = 0x00080000,
+        Processor21 = 0x00100000,
+        Processor22 = 0x00200000,
+        Processor23 = 0x00400000,
+        Processor24 = 0x00800000,
+        Processor25 = 0x01000000,
+        Processor26 = 0x02000000,
+        Processor27 = 0x04000000,
+        Processor28 = 0x08000000,
+        Processor29 = 0x10000000,
+        Processor30 = 0x20000000,
+        Processor31 = 0x40000000,
+        Processor32 = 0x80000000,
+        XAUDIO2_ANY_PROCESSOR = 0xffffffff,
+        XAUDIO2_DEFAULT_PROCESSOR = XAUDIO2_ANY_PROCESSOR
+    } XAUDIO2_WINDOWS_PROCESSOR_SPECIFIER, XAUDIO2_PROCESSOR;
+#endif
+
+// Used in XAUDIO2_DEVICE_DETAILS below to describe the types of applications
+// that the user has specified each device as a default for.  0 means that the
+// device isn't the default for any role.
+typedef enum XAUDIO2_DEVICE_ROLE
+{
+    NotDefaultDevice            = 0x0,
+    DefaultConsoleDevice        = 0x1,
+    DefaultMultimediaDevice     = 0x2,
+    DefaultCommunicationsDevice = 0x4,
+    DefaultGameDevice           = 0x8,
+    GlobalDefaultDevice         = 0xf,
+    InvalidDeviceRole = ~GlobalDefaultDevice
+} XAUDIO2_DEVICE_ROLE;
+
+// Returned by IXAudio2::GetDeviceDetails
+typedef struct XAUDIO2_DEVICE_DETAILS
+{
+    WCHAR DeviceID[256];                // String identifier for the audio device.
+    WCHAR DisplayName[256];             // Friendly name suitable for display to a human.
+    XAUDIO2_DEVICE_ROLE Role;           // Roles that the device should be used for.
+    WAVEFORMATEXTENSIBLE OutputFormat;  // The device's native PCM audio output format.
+} XAUDIO2_DEVICE_DETAILS;
+
+// Returned by IXAudio2Voice::GetVoiceDetails
+typedef struct XAUDIO2_VOICE_DETAILS
+{
+    UINT32 CreationFlags;               // Flags the voice was created with.
+    UINT32 InputChannels;               // Channels in the voice's input audio.
+    UINT32 InputSampleRate;             // Sample rate of the voice's input audio.
+} XAUDIO2_VOICE_DETAILS;
+
+// Used in XAUDIO2_VOICE_SENDS below
+typedef struct XAUDIO2_SEND_DESCRIPTOR
+{
+    UINT32 Flags;                       // Either 0 or XAUDIO2_SEND_USEFILTER.
+    IXAudio2Voice* pOutputVoice;        // This send's destination voice.
+} XAUDIO2_SEND_DESCRIPTOR;
+
+// Used in the voice creation functions and in IXAudio2Voice::SetOutputVoices
+typedef struct XAUDIO2_VOICE_SENDS
+{
+    UINT32 SendCount;                   // Number of sends from this voice.
+    XAUDIO2_SEND_DESCRIPTOR* pSends;    // Array of SendCount send descriptors.
+} XAUDIO2_VOICE_SENDS;
+
+// Used in XAUDIO2_EFFECT_CHAIN below
+typedef struct XAUDIO2_EFFECT_DESCRIPTOR
+{
+    IUnknown* pEffect;                  // Pointer to the effect object's IUnknown interface.
+    BOOL InitialState;                  // TRUE if the effect should begin in the enabled state.
+    UINT32 OutputChannels;              // How many output channels the effect should produce.
+} XAUDIO2_EFFECT_DESCRIPTOR;
+
+// Used in the voice creation functions and in IXAudio2Voice::SetEffectChain
+typedef struct XAUDIO2_EFFECT_CHAIN
+{
+    UINT32 EffectCount;                 // Number of effects in this voice's effect chain.
+    XAUDIO2_EFFECT_DESCRIPTOR* pEffectDescriptors; // Array of effect descriptors.
+} XAUDIO2_EFFECT_CHAIN;
+
+// Used in XAUDIO2_FILTER_PARAMETERS below
+typedef enum XAUDIO2_FILTER_TYPE
+{
+    LowPassFilter,                      // Attenuates frequencies above the cutoff frequency.
+    BandPassFilter,                     // Attenuates frequencies outside a given range.
+    HighPassFilter,                     // Attenuates frequencies below the cutoff frequency.
+    NotchFilter                         // Attenuates frequencies inside a given range.
+} XAUDIO2_FILTER_TYPE;
+
+// Used in IXAudio2Voice::Set/GetFilterParameters and Set/GetOutputFilterParameters
+typedef struct XAUDIO2_FILTER_PARAMETERS
+{
+    XAUDIO2_FILTER_TYPE Type;           // Low-pass, band-pass or high-pass.
+    float Frequency;                    // Radian frequency (2 * sin(pi*CutoffFrequency/SampleRate));
+                                        //  must be >= 0 and <= XAUDIO2_MAX_FILTER_FREQUENCY
+                                        //  (giving a maximum CutoffFrequency of SampleRate/6).
+    float OneOverQ;                     // Reciprocal of the filter's quality factor Q;
+                                        //  must be > 0 and <= XAUDIO2_MAX_FILTER_ONEOVERQ.
+} XAUDIO2_FILTER_PARAMETERS;
+
+// Used in IXAudio2SourceVoice::SubmitSourceBuffer
+typedef struct XAUDIO2_BUFFER
+{
+    UINT32 Flags;                       // Either 0 or XAUDIO2_END_OF_STREAM.
+    UINT32 AudioBytes;                  // Size of the audio data buffer in bytes.
+    BYTE* pAudioData;                   // Pointer to the audio data buffer.
+    UINT32 PlayBegin;                   // First sample in this buffer to be played.
+    UINT32 PlayLength;                  // Length of the region to be played in samples,
+                                        //  or 0 to play the whole buffer.
+    UINT32 LoopBegin;                   // First sample of the region to be looped.
+    UINT32 LoopLength;                  // Length of the desired loop region in samples,
+                                        //  or 0 to loop the entire buffer.
+    UINT32 LoopCount;                   // Number of times to repeat the loop region,
+                                        //  or XAUDIO2_LOOP_INFINITE to loop forever.
+    void* pContext;                     // Context value to be passed back in callbacks.
+} XAUDIO2_BUFFER;
+
+// Used in IXAudio2SourceVoice::SubmitSourceBuffer when submitting XWMA data.
+// NOTE: If an XWMA sound is submitted in more than one buffer, each buffer's
+// pDecodedPacketCumulativeBytes[PacketCount-1] value must be subtracted from
+// all the entries in the next buffer's pDecodedPacketCumulativeBytes array.
+// And whether a sound is submitted in more than one buffer or not, the final
+// buffer of the sound should use the XAUDIO2_END_OF_STREAM flag, or else the
+// client must call IXAudio2SourceVoice::Discontinuity after submitting it.
+typedef struct XAUDIO2_BUFFER_WMA
+{
+    UINT32* pDecodedPacketCumulativeBytes; // Decoded packet's cumulative size array.
+                                        //  Each element is the number of bytes accumulated
+                                        //  when the corresponding XWMA packet is decoded in
+                                        //  order.  The array must have PacketCount elements.
+    UINT32 PacketCount;                 // Number of XWMA packets submitted. Must be >= 1 and
+                                        //  divide evenly into XAUDIO2_BUFFER.AudioBytes.
+} XAUDIO2_BUFFER_WMA;
+
+// Returned by IXAudio2SourceVoice::GetState
+typedef struct XAUDIO2_VOICE_STATE
+{
+    void* pCurrentBufferContext;        // The pContext value provided in the XAUDIO2_BUFFER
+                                        //  that is currently being processed, or NULL if
+                                        //  there are no buffers in the queue.
+    UINT32 BuffersQueued;               // Number of buffers currently queued on the voice
+                                        //  (including the one that is being processed).
+    UINT64 SamplesPlayed;               // Total number of samples produced by the voice since
+                                        //  it began processing the current audio stream.
+} XAUDIO2_VOICE_STATE;
+
+// Returned by IXAudio2::GetPerformanceData
+typedef struct XAUDIO2_PERFORMANCE_DATA
+{
+    // CPU usage information
+    UINT64 AudioCyclesSinceLastQuery;   // CPU cycles spent on audio processing since the
+                                        //  last call to StartEngine or GetPerformanceData.
+    UINT64 TotalCyclesSinceLastQuery;   // Total CPU cycles elapsed since the last call
+                                        //  (only counts the CPU XAudio2 is running on).
+    UINT32 MinimumCyclesPerQuantum;     // Fewest CPU cycles spent processing any one
+                                        //  audio quantum since the last call.
+    UINT32 MaximumCyclesPerQuantum;     // Most CPU cycles spent processing any one
+                                        //  audio quantum since the last call.
+
+    // Memory usage information
+    UINT32 MemoryUsageInBytes;          // Total heap space currently in use.
+
+    // Audio latency and glitching information
+    UINT32 CurrentLatencyInSamples;     // Minimum delay from when a sample is read from a
+                                        //  source buffer to when it reaches the speakers.
+    UINT32 GlitchesSinceEngineStarted;  // Audio dropouts since the engine was started.
+
+    // Data about XAudio2's current workload
+    UINT32 ActiveSourceVoiceCount;      // Source voices currently playing.
+    UINT32 TotalSourceVoiceCount;       // Source voices currently existing.
+    UINT32 ActiveSubmixVoiceCount;      // Submix voices currently playing/existing.
+
+    UINT32 ActiveResamplerCount;        // Resample xAPOs currently active.
+    UINT32 ActiveMatrixMixCount;        // MatrixMix xAPOs currently active.
+
+    // Usage of the hardware XMA decoder (Xbox 360 only)
+    UINT32 ActiveXmaSourceVoices;       // Number of source voices decoding XMA data.
+    UINT32 ActiveXmaStreams;            // A voice can use more than one XMA stream.
+} XAUDIO2_PERFORMANCE_DATA;
+
+// Used in IXAudio2::SetDebugConfiguration
+typedef struct XAUDIO2_DEBUG_CONFIGURATION
+{
+    UINT32 TraceMask;                   // Bitmap of enabled debug message types.
+    UINT32 BreakMask;                   // Message types that will break into the debugger.
+    BOOL LogThreadID;                   // Whether to log the thread ID with each message.
+    BOOL LogFileline;                   // Whether to log the source file and line number.
+    BOOL LogFunctionName;               // Whether to log the function name.
+    BOOL LogTiming;                     // Whether to log message timestamps.
+} XAUDIO2_DEBUG_CONFIGURATION;
+
+// Values for the TraceMask and BreakMask bitmaps.  Only ERRORS and WARNINGS
+// are valid in BreakMask.  WARNINGS implies ERRORS, DETAIL implies INFO, and
+// FUNC_CALLS implies API_CALLS.  By default, TraceMask is ERRORS and WARNINGS
+// and all the other settings are zero.
+#define XAUDIO2_LOG_ERRORS     0x0001   // For handled errors with serious effects.
+#define XAUDIO2_LOG_WARNINGS   0x0002   // For handled errors that may be recoverable.
+#define XAUDIO2_LOG_INFO       0x0004   // Informational chit-chat (e.g. state changes).
+#define XAUDIO2_LOG_DETAIL     0x0008   // More detailed chit-chat.
+#define XAUDIO2_LOG_API_CALLS  0x0010   // Public API function entries and exits.
+#define XAUDIO2_LOG_FUNC_CALLS 0x0020   // Internal function entries and exits.
+#define XAUDIO2_LOG_TIMING     0x0040   // Delays detected and other timing data.
+#define XAUDIO2_LOG_LOCKS      0x0080   // Usage of critical sections and mutexes.
+#define XAUDIO2_LOG_MEMORY     0x0100   // Memory heap usage information.
+#define XAUDIO2_LOG_STREAMING  0x1000   // Audio streaming information.
+
+
+/**************************************************************************
+ *
+ * IXAudio2: Top-level XAudio2 COM interface.
+ *
+ **************************************************************************/
+
+// Use default arguments if compiling as C++
+#ifdef __cplusplus
+    #define X2DEFAULT(x) =x
+#else
+    #define X2DEFAULT(x)
+#endif
+
+#undef INTERFACE
+#define INTERFACE IXAudio2
+DECLARE_INTERFACE_(IXAudio2, IUnknown)
+{
+    // NAME: IXAudio2::QueryInterface
+    // DESCRIPTION: Queries for a given COM interface on the XAudio2 object.
+    //              Only IID_IUnknown and IID_IXAudio2 are supported.
+    //
+    // ARGUMENTS:
+    //  riid - IID of the interface to be obtained.
+    //  ppvInterface - Returns a pointer to the requested interface.
+    //
+    STDMETHOD(QueryInterface) (THIS_ REFIID riid, __deref_out void** ppvInterface) PURE;
+
+    // NAME: IXAudio2::AddRef
+    // DESCRIPTION: Adds a reference to the XAudio2 object.
+    //
+    STDMETHOD_(ULONG, AddRef) (THIS) PURE;
+
+    // NAME: IXAudio2::Release
+    // DESCRIPTION: Releases a reference to the XAudio2 object.
+    //
+    STDMETHOD_(ULONG, Release) (THIS) PURE;
+
+    // NAME: IXAudio2::GetDeviceCount
+    // DESCRIPTION: Returns the number of audio output devices available.
+    //
+    // ARGUMENTS:
+    //  pCount - Returns the device count.
+    //
+    STDMETHOD(GetDeviceCount) (THIS_ __out UINT32* pCount) PURE;
+
+    // NAME: IXAudio2::GetDeviceDetails
+    // DESCRIPTION: Returns information about the device with the given index.
+    //
+    // ARGUMENTS:
+    //  Index - Index of the device to be queried.
+    //  pDeviceDetails - Returns the device details.
+    //
+    STDMETHOD(GetDeviceDetails) (THIS_ UINT32 Index, __out XAUDIO2_DEVICE_DETAILS* pDeviceDetails) PURE;
+
+    // NAME: IXAudio2::Initialize
+    // DESCRIPTION: Sets global XAudio2 parameters and prepares it for use.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags specifying the XAudio2 object's behavior.  Currently unused.
+    //  XAudio2Processor - An XAUDIO2_PROCESSOR enumeration value that specifies
+    //  the hardware thread (Xbox) or processor (Windows) that XAudio2 will use.
+    //  The enumeration values are platform-specific; platform-independent code
+    //  can use XAUDIO2_DEFAULT_PROCESSOR to use the default on each platform.
+    //
+    STDMETHOD(Initialize) (THIS_ UINT32 Flags X2DEFAULT(0),
+                           XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR)) PURE;
+
+    // NAME: IXAudio2::RegisterForCallbacks
+    // DESCRIPTION: Adds a new client to receive XAudio2's engine callbacks.
+    //
+    // ARGUMENTS:
+    //  pCallback - Callback interface to be called during each processing pass.
+    //
+    STDMETHOD(RegisterForCallbacks) (__in IXAudio2EngineCallback* pCallback) PURE;
+
+    // NAME: IXAudio2::UnregisterForCallbacks
+    // DESCRIPTION: Removes an existing receiver of XAudio2 engine callbacks.
+    //
+    // ARGUMENTS:
+    //  pCallback - Previously registered callback interface to be removed.
+    //
+    STDMETHOD_(void, UnregisterForCallbacks) (__in IXAudio2EngineCallback* pCallback) PURE;
+
+    // NAME: IXAudio2::CreateSourceVoice
+    // DESCRIPTION: Creates and configures a source voice.
+    //
+    // ARGUMENTS:
+    //  ppSourceVoice - Returns the new object's IXAudio2SourceVoice interface.
+    //  pSourceFormat - Format of the audio that will be fed to the voice.
+    //  Flags - XAUDIO2_VOICE flags specifying the source voice's behavior.
+    //  MaxFrequencyRatio - Maximum SetFrequencyRatio argument to be allowed.
+    //  pCallback - Optional pointer to a client-provided callback interface.
+    //  pSendList - Optional list of voices this voice should send audio to.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateSourceVoice) (THIS_ __deref_out IXAudio2SourceVoice** ppSourceVoice,
+                                  __in const WAVEFORMATEX* pSourceFormat,
+                                  UINT32 Flags X2DEFAULT(0),
+                                  float MaxFrequencyRatio X2DEFAULT(XAUDIO2_DEFAULT_FREQ_RATIO),
+                                  __in_opt IXAudio2VoiceCallback* pCallback X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_VOICE_SENDS* pSendList X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2::CreateSubmixVoice
+    // DESCRIPTION: Creates and configures a submix voice.
+    //
+    // ARGUMENTS:
+    //  ppSubmixVoice - Returns the new object's IXAudio2SubmixVoice interface.
+    //  InputChannels - Number of channels in this voice's input audio data.
+    //  InputSampleRate - Sample rate of this voice's input audio data.
+    //  Flags - XAUDIO2_VOICE flags specifying the submix voice's behavior.
+    //  ProcessingStage - Arbitrary number that determines the processing order.
+    //  pSendList - Optional list of voices this voice should send audio to.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateSubmixVoice) (THIS_ __deref_out IXAudio2SubmixVoice** ppSubmixVoice,
+                                  UINT32 InputChannels, UINT32 InputSampleRate,
+                                  UINT32 Flags X2DEFAULT(0), UINT32 ProcessingStage X2DEFAULT(0),
+                                  __in_opt const XAUDIO2_VOICE_SENDS* pSendList X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+
+    // NAME: IXAudio2::CreateMasteringVoice
+    // DESCRIPTION: Creates and configures a mastering voice.
+    //
+    // ARGUMENTS:
+    //  ppMasteringVoice - Returns the new object's IXAudio2MasteringVoice interface.
+    //  InputChannels - Number of channels in this voice's input audio data.
+    //  InputSampleRate - Sample rate of this voice's input audio data.
+    //  Flags - XAUDIO2_VOICE flags specifying the mastering voice's behavior.
+    //  DeviceIndex - Identifier of the device to receive the output audio.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateMasteringVoice) (THIS_ __deref_out IXAudio2MasteringVoice** ppMasteringVoice,
+                                     UINT32 InputChannels X2DEFAULT(XAUDIO2_DEFAULT_CHANNELS),
+                                     UINT32 InputSampleRate X2DEFAULT(XAUDIO2_DEFAULT_SAMPLERATE),
+                                     UINT32 Flags X2DEFAULT(0), UINT32 DeviceIndex X2DEFAULT(0),
+                                     __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2::StartEngine
+    // DESCRIPTION: Creates and starts the audio processing thread.
+    //
+    STDMETHOD(StartEngine) (THIS) PURE;
+
+    // NAME: IXAudio2::StopEngine
+    // DESCRIPTION: Stops and destroys the audio processing thread.
+    //
+    STDMETHOD_(void, StopEngine) (THIS) PURE;
+
+    // NAME: IXAudio2::CommitChanges
+    // DESCRIPTION: Atomically applies a set of operations previously tagged
+    //              with a given identifier.
+    //
+    // ARGUMENTS:
+    //  OperationSet - Identifier of the set of operations to be applied.
+    //
+    STDMETHOD(CommitChanges) (THIS_ UINT32 OperationSet) PURE;
+
+    // NAME: IXAudio2::GetPerformanceData
+    // DESCRIPTION: Returns current resource usage details: memory, CPU, etc.
+    //
+    // ARGUMENTS:
+    //  pPerfData - Returns the performance data structure.
+    //
+    STDMETHOD_(void, GetPerformanceData) (THIS_ __out XAUDIO2_PERFORMANCE_DATA* pPerfData) PURE;
+
+    // NAME: IXAudio2::SetDebugConfiguration
+    // DESCRIPTION: Configures XAudio2's debug output (in debug builds only).
+    //
+    // ARGUMENTS:
+    //  pDebugConfiguration - Structure describing the debug output behavior.
+    //  pReserved - Optional parameter; must be NULL.
+    //
+    STDMETHOD_(void, SetDebugConfiguration) (THIS_ __in_opt const XAUDIO2_DEBUG_CONFIGURATION* pDebugConfiguration,
+                                             __in_opt __reserved void* pReserved X2DEFAULT(NULL)) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2Voice: Base voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2Voice
+DECLARE_INTERFACE(IXAudio2Voice)
+{
+    // These methods are declared in a macro so that the same declarations
+    // can be used in the derived voice types (IXAudio2SourceVoice, etc).
+
+    #define Declare_IXAudio2Voice_Methods() \
+    \
+    /* NAME: IXAudio2Voice::GetVoiceDetails
+    // DESCRIPTION: Returns the basic characteristics of this voice.
+    //
+    // ARGUMENTS:
+    //  pVoiceDetails - Returns the voice's details.
+    */\
+    STDMETHOD_(void, GetVoiceDetails) (THIS_ __out XAUDIO2_VOICE_DETAILS* pVoiceDetails) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputVoices
+    // DESCRIPTION: Replaces the set of submix/mastering voices that receive
+    //              this voice's output.
+    //
+    // ARGUMENTS:
+    //  pSendList - Optional list of voices this voice should send audio to.
+    */\
+    STDMETHOD(SetOutputVoices) (THIS_ __in_opt const XAUDIO2_VOICE_SENDS* pSendList) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetEffectChain
+    // DESCRIPTION: Replaces this voice's current effect chain with a new one.
+    //
+    // ARGUMENTS:
+    //  pEffectChain - Structure describing the new effect chain to be used.
+    */\
+    STDMETHOD(SetEffectChain) (THIS_ __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain) PURE; \
+    \
+    /* NAME: IXAudio2Voice::EnableEffect
+    // DESCRIPTION: Enables an effect in this voice's effect chain.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(EnableEffect) (THIS_ UINT32 EffectIndex, \
+                             UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::DisableEffect
+    // DESCRIPTION: Disables an effect in this voice's effect chain.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(DisableEffect) (THIS_ UINT32 EffectIndex, \
+                              UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetEffectState
+    // DESCRIPTION: Returns the running state of an effect.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pEnabled - Returns the enabled/disabled state of the given effect.
+    */\
+    STDMETHOD_(void, GetEffectState) (THIS_ UINT32 EffectIndex, __out BOOL* pEnabled) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetEffectParameters
+    // DESCRIPTION: Sets effect-specific parameters.
+    //
+    // REMARKS: Unlike IXAPOParameters::SetParameters, this method may
+    //          be called from any thread.  XAudio2 implements
+    //          appropriate synchronization to copy the parameters to the
+    //          realtime audio processing thread.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pParameters - Pointer to an effect-specific parameters block.
+    //  ParametersByteSize - Size of the pParameters array  in bytes.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetEffectParameters) (THIS_ UINT32 EffectIndex, \
+                                    __in_bcount(ParametersByteSize) const void* pParameters, \
+                                    UINT32 ParametersByteSize, \
+                                    UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetEffectParameters
+    // DESCRIPTION: Obtains the current effect-specific parameters.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pParameters - Returns the current values of the effect-specific parameters.
+    //  ParametersByteSize - Size of the pParameters array in bytes.
+    */\
+    STDMETHOD(GetEffectParameters) (THIS_ UINT32 EffectIndex, \
+                                    __out_bcount(ParametersByteSize) void* pParameters, \
+                                    UINT32 ParametersByteSize) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetFilterParameters
+    // DESCRIPTION: Sets this voice's filter parameters.
+    //
+    // ARGUMENTS:
+    //  pParameters - Pointer to the filter's parameter structure.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetFilterParameters) (THIS_ __in const XAUDIO2_FILTER_PARAMETERS* pParameters, \
+                                    UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetFilterParameters
+    // DESCRIPTION: Returns this voice's current filter parameters.
+    //
+    // ARGUMENTS:
+    //  pParameters - Returns the filter parameters.
+    */\
+    STDMETHOD_(void, GetFilterParameters) (THIS_ __out XAUDIO2_FILTER_PARAMETERS* pParameters) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputFilterParameters
+    // DESCRIPTION: Sets the filter parameters on one of this voice's sends.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - Destination voice of the send whose filter parameters will be set.
+    //  pParameters - Pointer to the filter's parameter structure.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetOutputFilterParameters) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                          __in const XAUDIO2_FILTER_PARAMETERS* pParameters, \
+                                          UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetOutputFilterParameters
+    // DESCRIPTION: Returns the filter parameters from one of this voice's sends.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - Destination voice of the send whose filter parameters will be read.
+    //  pParameters - Returns the filter parameters.
+    */\
+    STDMETHOD_(void, GetOutputFilterParameters) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                                 __out XAUDIO2_FILTER_PARAMETERS* pParameters) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetVolume
+    // DESCRIPTION: Sets this voice's overall volume level.
+    //
+    // ARGUMENTS:
+    //  Volume - New overall volume level to be used, as an amplitude factor.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetVolume) (THIS_ float Volume, \
+                          UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetVolume
+    // DESCRIPTION: Obtains this voice's current overall volume level.
+    //
+    // ARGUMENTS:
+    //  pVolume: Returns the voice's current overall volume level.
+    */\
+    STDMETHOD_(void, GetVolume) (THIS_ __out float* pVolume) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetChannelVolumes
+    // DESCRIPTION: Sets this voice's per-channel volume levels.
+    //
+    // ARGUMENTS:
+    //  Channels - Used to confirm the voice's channel count.
+    //  pVolumes - Array of per-channel volume levels to be used.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetChannelVolumes) (THIS_ UINT32 Channels, __in_ecount(Channels) const float* pVolumes, \
+                                  UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetChannelVolumes
+    // DESCRIPTION: Returns this voice's current per-channel volume levels.
+    //
+    // ARGUMENTS:
+    //  Channels - Used to confirm the voice's channel count.
+    //  pVolumes - Returns an array of the current per-channel volume levels.
+    */\
+    STDMETHOD_(void, GetChannelVolumes) (THIS_ UINT32 Channels, __out_ecount(Channels) float* pVolumes) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputMatrix
+    // DESCRIPTION: Sets the volume levels used to mix from each channel of this
+    //              voice's output audio to each channel of a given destination
+    //              voice's input audio.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - The destination voice whose mix matrix to change.
+    //  SourceChannels - Used to confirm this voice's output channel count
+    //   (the number of channels produced by the last effect in the chain).
+    //  DestinationChannels - Confirms the destination voice's input channels.
+    //  pLevelMatrix - Array of [SourceChannels * DestinationChannels] send
+    //   levels.  The level used to send from source channel S to destination
+    //   channel D should be in pLevelMatrix[S + SourceChannels * D].
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetOutputMatrix) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                UINT32 SourceChannels, UINT32 DestinationChannels, \
+                                __in_ecount(SourceChannels * DestinationChannels) const float* pLevelMatrix, \
+                                UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetOutputMatrix
+    // DESCRIPTION: Obtains the volume levels used to send each channel of this
+    //              voice's output audio to each channel of a given destination
+    //              voice's input audio.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - The destination voice whose mix matrix to obtain.
+    //  SourceChannels - Used to confirm this voice's output channel count
+    //   (the number of channels produced by the last effect in the chain).
+    //  DestinationChannels - Confirms the destination voice's input channels.
+    //  pLevelMatrix - Array of send levels, as above.
+    */\
+    STDMETHOD_(void, GetOutputMatrix) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                       UINT32 SourceChannels, UINT32 DestinationChannels, \
+                                       __out_ecount(SourceChannels * DestinationChannels) float* pLevelMatrix) PURE; \
+    \
+    /* NAME: IXAudio2Voice::DestroyVoice
+    // DESCRIPTION: Destroys this voice, stopping it if necessary and removing
+    //              it from the XAudio2 graph.
+    */\
+    STDMETHOD_(void, DestroyVoice) (THIS) PURE
+
+    Declare_IXAudio2Voice_Methods();
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2SourceVoice: Source voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2SourceVoice
+DECLARE_INTERFACE_(IXAudio2SourceVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // NAME: IXAudio2SourceVoice::Start
+    // DESCRIPTION: Makes this voice start consuming and processing audio.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags controlling how the voice should be started.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(Start) (THIS_ UINT32 Flags X2DEFAULT(0), UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::Stop
+    // DESCRIPTION: Makes this voice stop consuming audio.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags controlling how the voice should be stopped.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(Stop) (THIS_ UINT32 Flags X2DEFAULT(0), UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::SubmitSourceBuffer
+    // DESCRIPTION: Adds a new audio buffer to this voice's input queue.
+    //
+    // ARGUMENTS:
+    //  pBuffer - Pointer to the buffer structure to be queued.
+    //  pBufferWMA - Additional structure used only when submitting XWMA data.
+    //
+    STDMETHOD(SubmitSourceBuffer) (THIS_ __in const XAUDIO2_BUFFER* pBuffer, __in_opt const XAUDIO2_BUFFER_WMA* pBufferWMA X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2SourceVoice::FlushSourceBuffers
+    // DESCRIPTION: Removes all pending audio buffers from this voice's queue.
+    //
+    STDMETHOD(FlushSourceBuffers) (THIS) PURE;
+
+    // NAME: IXAudio2SourceVoice::Discontinuity
+    // DESCRIPTION: Notifies the voice of an intentional break in the stream of
+    //              audio buffers (e.g. the end of a sound), to prevent XAudio2
+    //              from interpreting an empty buffer queue as a glitch.
+    //
+    STDMETHOD(Discontinuity) (THIS) PURE;
+
+    // NAME: IXAudio2SourceVoice::ExitLoop
+    // DESCRIPTION: Breaks out of the current loop when its end is reached.
+    //
+    // ARGUMENTS:
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(ExitLoop) (THIS_ UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::GetState
+    // DESCRIPTION: Returns the number of buffers currently queued on this voice,
+    //              the pContext value associated with the currently processing
+    //              buffer (if any), and other voice state information.
+    //
+    // ARGUMENTS:
+    //  pVoiceState - Returns the state information.
+    //
+    STDMETHOD_(void, GetState) (THIS_ __out XAUDIO2_VOICE_STATE* pVoiceState) PURE;
+
+    // NAME: IXAudio2SourceVoice::SetFrequencyRatio
+    // DESCRIPTION: Sets this voice's frequency adjustment, i.e. its pitch.
+    //
+    // ARGUMENTS:
+    //  Ratio - Frequency change, expressed as source frequency / target frequency.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(SetFrequencyRatio) (THIS_ float Ratio,
+                                  UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::GetFrequencyRatio
+    // DESCRIPTION: Returns this voice's current frequency adjustment ratio.
+    //
+    // ARGUMENTS:
+    //  pRatio - Returns the frequency adjustment.
+    //
+    STDMETHOD_(void, GetFrequencyRatio) (THIS_ __out float* pRatio) PURE;
+
+    // NAME: IXAudio2SourceVoice::SetSourceSampleRate
+    // DESCRIPTION: Reconfigures this voice to treat its source data as being
+    //              at a different sample rate than the original one specified
+    //              in CreateSourceVoice's pSourceFormat argument.
+    //
+    // ARGUMENTS:
+    //  UINT32 - The intended sample rate of further submitted source data.
+    //
+    STDMETHOD(SetSourceSampleRate) (THIS_ UINT32 NewSourceSampleRate) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2SubmixVoice: Submixing voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2SubmixVoice
+DECLARE_INTERFACE_(IXAudio2SubmixVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // There are currently no methods specific to submix voices.
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2MasteringVoice: Mastering voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2MasteringVoice
+DECLARE_INTERFACE_(IXAudio2MasteringVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // There are currently no methods specific to mastering voices.
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2EngineCallback: Client notification interface for engine events.
+ *
+ * REMARKS: Contains methods to notify the client when certain events happen
+ *          in the XAudio2 engine.  This interface should be implemented by
+ *          the client.  XAudio2 will call these methods via the interface
+ *          pointer provided by the client when it calls XAudio2Create or
+ *          IXAudio2::Initialize.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2EngineCallback
+DECLARE_INTERFACE(IXAudio2EngineCallback)
+{
+    // Called by XAudio2 just before an audio processing pass begins.
+    STDMETHOD_(void, OnProcessingPassStart) (THIS) PURE;
+
+    // Called just after an audio processing pass ends.
+    STDMETHOD_(void, OnProcessingPassEnd) (THIS) PURE;
+
+    // Called in the event of a critical system error which requires XAudio2
+    // to be closed down and restarted.  The error code is given in Error.
+    STDMETHOD_(void, OnCriticalError) (THIS_ HRESULT Error) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2VoiceCallback: Client notification interface for voice events.
+ *
+ * REMARKS: Contains methods to notify the client when certain events happen
+ *          in an XAudio2 voice.  This interface should be implemented by the
+ *          client.  XAudio2 will call these methods via an interface pointer
+ *          provided by the client in the IXAudio2::CreateSourceVoice call.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2VoiceCallback
+DECLARE_INTERFACE(IXAudio2VoiceCallback)
+{
+    // Called just before this voice's processing pass begins.
+    STDMETHOD_(void, OnVoiceProcessingPassStart) (THIS_ UINT32 BytesRequired) PURE;
+
+    // Called just after this voice's processing pass ends.
+    STDMETHOD_(void, OnVoiceProcessingPassEnd) (THIS) PURE;
+
+    // Called when this voice has just finished playing a buffer stream
+    // (as marked with the XAUDIO2_END_OF_STREAM flag on the last buffer).
+    STDMETHOD_(void, OnStreamEnd) (THIS) PURE;
+
+    // Called when this voice is about to start processing a new buffer.
+    STDMETHOD_(void, OnBufferStart) (THIS_ void* pBufferContext) PURE;
+
+    // Called when this voice has just finished processing a buffer.
+    // The buffer can now be reused or destroyed.
+    STDMETHOD_(void, OnBufferEnd) (THIS_ void* pBufferContext) PURE;
+
+    // Called when this voice has just reached the end position of a loop.
+    STDMETHOD_(void, OnLoopEnd) (THIS_ void* pBufferContext) PURE;
+
+    // Called in the event of a critical error during voice processing,
+    // such as a failing xAPO or an error from the hardware XMA decoder.
+    // The voice may have to be destroyed and re-created to recover from
+    // the error.  The callback arguments report which buffer was being
+    // processed when the error occurred, and its HRESULT code.
+    STDMETHOD_(void, OnVoiceError) (THIS_ void* pBufferContext, HRESULT Error) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * Macros to make it easier to use the XAudio2 COM interfaces in C code.
+ *
+ **************************************************************************/
+
+#ifndef __cplusplus
+
+// IXAudio2
+#define IXAudio2_QueryInterface(This,riid,ppvInterface) ((This)->lpVtbl->QueryInterface(This,riid,ppvInterface))
+#define IXAudio2_AddRef(This) ((This)->lpVtbl->AddRef(This))
+#define IXAudio2_Release(This) ((This)->lpVtbl->Release(This))
+#define IXAudio2_GetDeviceCount(This,puCount) ((This)->lpVtbl->GetDeviceCount(This,puCount))
+#define IXAudio2_GetDeviceDetails(This,Index,pDeviceDetails) ((This)->lpVtbl->GetDeviceDetails(This,Index,pDeviceDetails))
+#define IXAudio2_Initialize(This,Flags,XAudio2Processor) ((This)->lpVtbl->Initialize(This,Flags,XAudio2Processor))
+#define IXAudio2_CreateSourceVoice(This,ppSourceVoice,pSourceFormat,Flags,MaxFrequencyRatio,pCallback,pSendList,pEffectChain) ((This)->lpVtbl->CreateSourceVoice(This,ppSourceVoice,pSourceFormat,Flags,MaxFrequencyRatio,pCallback,pSendList,pEffectChain))
+#define IXAudio2_CreateSubmixVoice(This,ppSubmixVoice,InputChannels,InputSampleRate,Flags,ProcessingStage,pSendList,pEffectChain) ((This)->lpVtbl->CreateSubmixVoice(This,ppSubmixVoice,InputChannels,InputSampleRate,Flags,ProcessingStage,pSendList,pEffectChain))
+#define IXAudio2_CreateMasteringVoice(This,ppMasteringVoice,InputChannels,InputSampleRate,Flags,DeviceIndex,pEffectChain) ((This)->lpVtbl->CreateMasteringVoice(This,ppMasteringVoice,InputChannels,InputSampleRate,Flags,DeviceIndex,pEffectChain))
+#define IXAudio2_StartEngine(This) ((This)->lpVtbl->StartEngine(This))
+#define IXAudio2_StopEngine(This) ((This)->lpVtbl->StopEngine(This))
+#define IXAudio2_CommitChanges(This,OperationSet) ((This)->lpVtbl->CommitChanges(This,OperationSet))
+#define IXAudio2_GetPerformanceData(This,pPerfData) ((This)->lpVtbl->GetPerformanceData(This,pPerfData))
+#define IXAudio2_SetDebugConfiguration(This,pDebugConfiguration,pReserved) ((This)->lpVtbl->SetDebugConfiguration(This,pDebugConfiguration,pReserved))
+
+// IXAudio2Voice
+#define IXAudio2Voice_GetVoiceDetails(This,pVoiceDetails) ((This)->lpVtbl->GetVoiceDetails(This,pVoiceDetails))
+#define IXAudio2Voice_SetOutputVoices(This,pSendList) ((This)->lpVtbl->SetOutputVoices(This,pSendList))
+#define IXAudio2Voice_SetEffectChain(This,pEffectChain) ((This)->lpVtbl->SetEffectChain(This,pEffectChain))
+#define IXAudio2Voice_EnableEffect(This,EffectIndex,OperationSet) ((This)->lpVtbl->EnableEffect(This,EffectIndex,OperationSet))
+#define IXAudio2Voice_DisableEffect(This,EffectIndex,OperationSet) ((This)->lpVtbl->DisableEffect(This,EffectIndex,OperationSet))
+#define IXAudio2Voice_GetEffectState(This,EffectIndex,pEnabled) ((This)->lpVtbl->GetEffectState(This,EffectIndex,pEnabled))
+#define IXAudio2Voice_SetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize, OperationSet) ((This)->lpVtbl->SetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize,OperationSet))
+#define IXAudio2Voice_GetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize) ((This)->lpVtbl->GetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize))
+#define IXAudio2Voice_SetFilterParameters(This,pParameters,OperationSet) ((This)->lpVtbl->SetFilterParameters(This,pParameters,OperationSet))
+#define IXAudio2Voice_GetFilterParameters(This,pParameters) ((This)->lpVtbl->GetFilterParameters(This,pParameters))
+#define IXAudio2Voice_SetOutputFilterParameters(This,pDestinationVoice,pParameters,OperationSet) ((This)->lpVtbl->SetOutputFilterParameters(This,pDestinationVoice,pParameters,OperationSet))
+#define IXAudio2Voice_GetOutputFilterParameters(This,pDestinationVoice,pParameters) ((This)->lpVtbl->GetOutputFilterParameters(This,pDestinationVoice,pParameters))
+#define IXAudio2Voice_SetVolume(This,Volume,OperationSet) ((This)->lpVtbl->SetVolume(This,Volume,OperationSet))
+#define IXAudio2Voice_GetVolume(This,pVolume) ((This)->lpVtbl->GetVolume(This,pVolume))
+#define IXAudio2Voice_SetChannelVolumes(This,Channels,pVolumes,OperationSet) ((This)->lpVtbl->SetChannelVolumes(This,Channels,pVolumes,OperationSet))
+#define IXAudio2Voice_GetChannelVolumes(This,Channels,pVolumes) ((This)->lpVtbl->GetChannelVolumes(This,Channels,pVolumes))
+#define IXAudio2Voice_SetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix,OperationSet) ((This)->lpVtbl->SetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix,OperationSet))
+#define IXAudio2Voice_GetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix) ((This)->lpVtbl->GetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix))
+#define IXAudio2Voice_DestroyVoice(This) ((This)->lpVtbl->DestroyVoice(This))
+
+// IXAudio2SourceVoice
+#define IXAudio2SourceVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2SourceVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2SourceVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2SourceVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2SourceVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2SourceVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2SourceVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2SourceVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2SourceVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2SourceVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2SourceVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2SourceVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2SourceVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2SourceVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2SourceVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2SourceVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2SourceVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2SourceVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2SourceVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+#define IXAudio2SourceVoice_Start(This,Flags,OperationSet) ((This)->lpVtbl->Start(This,Flags,OperationSet))
+#define IXAudio2SourceVoice_Stop(This,Flags,OperationSet) ((This)->lpVtbl->Stop(This,Flags,OperationSet))
+#define IXAudio2SourceVoice_SubmitSourceBuffer(This,pBuffer,pBufferWMA) ((This)->lpVtbl->SubmitSourceBuffer(This,pBuffer,pBufferWMA))
+#define IXAudio2SourceVoice_FlushSourceBuffers(This) ((This)->lpVtbl->FlushSourceBuffers(This))
+#define IXAudio2SourceVoice_Discontinuity(This) ((This)->lpVtbl->Discontinuity(This))
+#define IXAudio2SourceVoice_ExitLoop(This,OperationSet) ((This)->lpVtbl->ExitLoop(This,OperationSet))
+#define IXAudio2SourceVoice_GetState(This,pVoiceState) ((This)->lpVtbl->GetState(This,pVoiceState))
+#define IXAudio2SourceVoice_SetFrequencyRatio(This,Ratio,OperationSet) ((This)->lpVtbl->SetFrequencyRatio(This,Ratio,OperationSet))
+#define IXAudio2SourceVoice_GetFrequencyRatio(This,pRatio) ((This)->lpVtbl->GetFrequencyRatio(This,pRatio))
+#define IXAudio2SourceVoice_SetSourceSampleRate(This,NewSourceSampleRate) ((This)->lpVtbl->SetSourceSampleRate(This,NewSourceSampleRate))
+
+// IXAudio2SubmixVoice
+#define IXAudio2SubmixVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2SubmixVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2SubmixVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2SubmixVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2SubmixVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2SubmixVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2SubmixVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2SubmixVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2SubmixVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2SubmixVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2SubmixVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2SubmixVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2SubmixVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2SubmixVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2SubmixVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2SubmixVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2SubmixVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2SubmixVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2SubmixVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+
+// IXAudio2MasteringVoice
+#define IXAudio2MasteringVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2MasteringVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2MasteringVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2MasteringVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2MasteringVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2MasteringVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2MasteringVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2MasteringVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2MasteringVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2MasteringVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2MasteringVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2MasteringVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2MasteringVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2MasteringVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2MasteringVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2MasteringVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2MasteringVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2MasteringVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2MasteringVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+
+#endif // #ifndef __cplusplus
+
+
+/**************************************************************************
+ *
+ * Utility functions used to convert from pitch in semitones and volume
+ * in decibels to the frequency and amplitude ratio units used by XAudio2.
+ * These are only defined if the client #defines XAUDIO2_HELPER_FUNCTIONS
+ * prior to #including xaudio2.h.
+ *
+ **************************************************************************/
+
+#ifdef XAUDIO2_HELPER_FUNCTIONS
+
+#define _USE_MATH_DEFINES   // Make math.h define M_PI
+#include <math.h>           // For powf, log10f, sinf and asinf
+
+// Calculate the argument to SetVolume from a decibel value
+__inline float XAudio2DecibelsToAmplitudeRatio(float Decibels)
+{
+    return powf(10.0f, Decibels / 20.0f);
+}
+
+// Recover a volume in decibels from an amplitude factor
+__inline float XAudio2AmplitudeRatioToDecibels(float Volume)
+{
+    if (Volume == 0)
+    {
+        return -3.402823466e+38f; // Smallest float value (-FLT_MAX)
+    }
+    return 20.0f * log10f(Volume);
+}
+
+// Calculate the argument to SetFrequencyRatio from a semitone value
+__inline float XAudio2SemitonesToFrequencyRatio(float Semitones)
+{
+    // FrequencyRatio = 2 ^ Octaves
+    //                = 2 ^ (Semitones / 12)
+    return powf(2.0f, Semitones / 12.0f);
+}
+
+// Recover a pitch in semitones from a frequency ratio
+__inline float XAudio2FrequencyRatioToSemitones(float FrequencyRatio)
+{
+    // Semitones = 12 * log2(FrequencyRatio)
+    //           = 12 * log2(10) * log10(FrequencyRatio)
+    return 39.86313713864835f * log10f(FrequencyRatio);
+}
+
+// Convert from filter cutoff frequencies expressed in Hertz to the radian
+// frequency values used in XAUDIO2_FILTER_PARAMETERS.Frequency.  Note that
+// the highest CutoffFrequency supported is SampleRate/6.  Higher values of
+// CutoffFrequency will return XAUDIO2_MAX_FILTER_FREQUENCY.
+__inline float XAudio2CutoffFrequencyToRadians(float CutoffFrequency, UINT32 SampleRate)
+{
+    if ((UINT32)(CutoffFrequency * 6.0f) >= SampleRate)
+    {
+        return XAUDIO2_MAX_FILTER_FREQUENCY;
+    }
+    return 2.0f * sinf((float)M_PI * CutoffFrequency / SampleRate);
+}
+
+// Convert from radian frequencies back to absolute frequencies in Hertz
+__inline float XAudio2RadiansToCutoffFrequency(float Radians, float SampleRate)
+{
+    return SampleRate * asinf(Radians / 2.0f) / (float)M_PI;
+}
+#endif // #ifdef XAUDIO2_HELPER_FUNCTIONS
+
+
+/**************************************************************************
+ *
+ * XAudio2Create: Top-level function that creates an XAudio2 instance.
+ *
+ * On Windows this is just an inline function that calls CoCreateInstance
+ * and Initialize.  The arguments are described above, under Initialize,
+ * except that the XAUDIO2_DEBUG_ENGINE flag can be used here to select
+ * the debug version of XAudio2.
+ *
+ * On Xbox, this function is implemented in the XAudio2 library, and the
+ * XAUDIO2_DEBUG_ENGINE flag has no effect; the client must explicitly
+ * link with the debug version of the library to obtain debug behavior.
+ *
+ **************************************************************************/
+
+#ifdef _XBOX
+
+STDAPI XAudio2Create(__deref_out IXAudio2** ppXAudio2, UINT32 Flags X2DEFAULT(0),
+                     XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR));
+
+#else // Windows
+
+__inline HRESULT XAudio2Create(__deref_out IXAudio2** ppXAudio2, UINT32 Flags X2DEFAULT(0),
+                               XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR))
+{
+    // Instantiate the appropriate XAudio2 engine
+    IXAudio2* pXAudio2;
+
+    #ifdef __cplusplus
+
+        HRESULT hr = CoCreateInstance((Flags & XAUDIO2_DEBUG_ENGINE) ? __uuidof(XAudio2_Debug) : __uuidof(XAudio2),
+                                      NULL, CLSCTX_INPROC_SERVER, __uuidof(IXAudio2), (void**)&pXAudio2);
+        if (SUCCEEDED(hr))
+        {
+            hr = pXAudio2->Initialize(Flags, XAudio2Processor);
+
+            if (SUCCEEDED(hr))
+            {
+                *ppXAudio2 = pXAudio2;
+            }
+            else
+            {
+                pXAudio2->Release();
+            }
+        }
+
+    #else
+
+        HRESULT hr = CoCreateInstance((Flags & XAUDIO2_DEBUG_ENGINE) ? &CLSID_XAudio2_Debug : &CLSID_XAudio2,
+                                      NULL, CLSCTX_INPROC_SERVER, &IID_IXAudio2, (void**)&pXAudio2);
+        if (SUCCEEDED(hr))
+        {
+            hr = pXAudio2->lpVtbl->Initialize(pXAudio2, Flags, XAudio2Processor);
+
+            if (SUCCEEDED(hr))
+            {
+                *ppXAudio2 = pXAudio2;
+            }
+            else
+            {
+                pXAudio2->lpVtbl->Release(pXAudio2);
+            }
+        }
+
+    #endif // #ifdef __cplusplus
+
+    return hr;
+}
+
+#endif // #ifdef _XBOX
+
+
+// Undo the #pragma pack(push, 1) directive at the top of this file
+#pragma pack(pop)
+
+#endif // #ifndef GUID_DEFS_ONLY
+#endif // #ifndef __XAUDIO2_INCLUDED__

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -13,6 +13,7 @@ mkdir Mupen64plusHLE
 
 set FLAGS_x86=-O3^
  -I%obj%/dx_mingw^
+ -DXAUDIO_LIBRARIES_UNAVAILABLE^
  -masm=intel^
  -msse2^
  -mstackrealign
@@ -71,5 +72,5 @@ set OBJ_LIST=^
 %obj%/Mupen64plusHLE/musyx.o
 
 ECHO Linking assembled object files...
-g++ -o %obj%/AziAudio.dll %OBJ_LIST% --shared -s
+g++ -o %obj%/AziAudio.dll %OBJ_LIST% -ldsound --shared -s
 PAUSE

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -1,0 +1,75 @@
+@ECHO OFF
+TITLE MinGW Compiler Suite Invocation
+
+set MinGW=C:/MinGW
+set src=%CD%/AziAudio
+set obj=%CD%/gccbuild
+
+if not exist gccbuild (
+mkdir gccbuild
+cd gccbuild
+mkdir Mupen64plusHLE
+)
+
+set FLAGS_x86=-O3^
+ -I%obj%/dx_mingw^
+ -masm=intel^
+ -msse2^
+ -mstackrealign
+set C_FLAGS=%FLAGS_X86%
+
+cd %MinGW%/bin
+
+ECHO Compiling sources...
+gcc -o %obj%/Mupen64plusHLE/audio.asm           %src%/Mupen64plusHLE/audio.c          -S %C_FLAGS%
+gcc -o %obj%/Mupen64plusHLE/memory.asm          %src%/Mupen64plusHLE/memory.c         -S %C_FLAGS%
+gcc -o %obj%/Mupen64plusHLE/Mupen64Support.asm  %src%/Mupen64plusHLE/Mupen64Support.c -S %C_FLAGS%
+gcc -o %obj%/Mupen64plusHLE/musyx.asm           %src%/Mupen64plusHLE/musyx.c          -S %C_FLAGS%
+g++ -o %obj%/ABI1.asm                   %src%/ABI1.cpp                  -S %C_FLAGS%
+g++ -o %obj%/ABI2.asm                   %src%/ABI2.cpp                  -S %C_FLAGS%
+g++ -o %obj%/ABI3.asm                   %src%/ABI3.cpp                  -S %C_FLAGS%
+g++ -o %obj%/ABI3mp3.asm                %src%/ABI3mp3.cpp               -S %C_FLAGS%
+g++ -o %obj%/DirectSoundDriver.asm      %src%/DirectSoundDriver.cpp     -S %C_FLAGS%
+g++ -o %obj%/HLEMain.asm                %src%/HLEMain.cpp               -S %C_FLAGS%
+g++ -o %obj%/main.asm                   %src%/main.cpp                  -S %C_FLAGS%
+g++ -o %obj%/SafeABI.asm                %src%/SafeABI.cpp               -S %C_FLAGS%
+g++ -o %obj%/WaveOut.asm                %src%/WaveOut.cpp               -S %C_FLAGS%
+g++ -o %obj%/XAudio2SoundDriver.asm     %src%/XAudio2SoundDriver.cpp    -S %C_FLAGS%
+
+ECHO Assembling compiled sources...
+as -o %obj%/ABI1.o                          %obj%/ABI1.asm
+as -o %obj%/ABI2.o                          %obj%/ABI2.asm
+as -o %obj%/ABI3.o                          %obj%/ABI3.asm
+as -o %obj%/ABI3mp3.o                       %obj%/ABI3mp3.asm
+as -o %obj%/DirectSoundDriver.o             %obj%/DirectSoundDriver.asm
+as -o %obj%/HLEMain.o                       %obj%/HLEMain.asm
+as -o %obj%/main.o                          %obj%/main.asm
+as -o %obj%/SafeABI.o                       %obj%/SafeABI.asm
+as -o %obj%/WaveOut.o                       %obj%/WaveOut.asm
+as -o %obj%/XAudio2SoundDriver.o            %obj%/XAudio2SoundDriver.asm
+
+as -o %obj%/Mupen64plusHLE/audio.o          %obj%/Mupen64plusHLE/audio.asm
+as -o %obj%/Mupen64plusHLE/memory.o         %obj%/Mupen64plusHLE/memory.asm
+as -o %obj%/Mupen64plusHLE/Mupen64Support.o %obj%/Mupen64plusHLE/Mupen64Support.asm
+as -o %obj%/Mupen64plusHLE/musyx.o          %obj%/Mupen64plusHLE/musyx.asm
+ECHO.
+
+set OBJ_LIST=^
+%obj%/ABI1.o ^
+%obj%/ABI2.o ^
+%obj%/ABI3.o ^
+%obj%/ABI3mp3.o ^
+%obj%/DirectSoundDriver.o ^
+%obj%/HLEMain.o ^
+%obj%/main.o ^
+%obj%/SafeABI.o ^
+%obj%/WaveOut.o ^
+%obj%/XAudio2SoundDriver.o ^
+%obj%/Mupen64plusHLE/audio.o ^
+%obj%/Mupen64plusHLE/memory.o ^
+%obj%/Mupen64plusHLE/Mupen64Support.o ^
+%obj%/Mupen64plusHLE/musyx.o
+
+ECHO Linking assembled object files...
+g++ -o %obj%/AziAudio.dll %OBJ_LIST% --shared -s
+PAUSE


### PR DESCRIPTION
I wanted to give it a try to see how hard it might be to get this plugin to compile using MinGW.  I was afraid it would be a wasted effort, but actually it just took a few changes (less than 20 generally small and divided commits, outlined below).

I guess I'm mostly a portability geek, so it was partly for fun, but then again, there are both pros and cons to linking Windows binaries with MinGW instead of Microsoft Visual C++.  (50% of the time I'd say the pros outweigh the cons 100% of the time.)  At the very least, it opens up the possibility for testing the plugin built by a different compiler, which might help isolate whether some bugs are problems in the C++ code or unspecified behavior that varies between compiler to compiler.

Unfortunately, I do not have `XAudio2.h` handy on me in my compiler toolchain...I did however have access to `dsound.h` and libdsound.a, so I was able to compile and link this plugin using MinGW for DirectSound.  I wish that in the future the same can be said for XAudio2...a quick search shows that some people have made it happen, but I have yet to play with that.

Needless to say it took more changes than are usually done in one straightforward pull request, so I'll try to resolve any potential issues in any of my commits or answer any questions that may need answering.