### PR TITLE
fixed all the level 3 MSVC compiler warnings

### DIFF
--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -15,9 +15,16 @@
 extern u8 BufferSpace[0x10000];
 
 static void SPNOOP () {
-	char buff[0x100];
-	sprintf (buff, "Unknown/Unimplemented Audio Command %i in ABI 2", k0 >> 24);
-	MessageBox (NULL, buff, "Audio HLE Error", MB_OK);
+    static char buff[] = "Unknown/Unimplemented Audio Command %i in ABI 2";
+    char * sprintf_offset;
+    const u8 command = (unsigned char)((k0 & 0xFF000000ul) >> 24);
+
+    sprintf_offset = strchr(&buff[0], '%'); /* Overwrite "%i" with decimal. */
+    *(sprintf_offset + 0) = '0' + (command/10 % 10);
+    *(sprintf_offset + 1) = '0' + (command/ 1 % 10);
+    if (sprintf_offset[0] == '0')
+        sprintf_offset[0] = ' '; /* Leading 0's may confuse decimal w/ octal. */
+    MessageBox (NULL, buff, "Audio HLE Error", MB_OK);
 }
 extern u16 AudioInBuffer;		// 0x0000(T8)
 extern u16 AudioOutBuffer;		// 0x0002(T8)

--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -24,7 +24,7 @@ static void SPNOOP () {
     *(sprintf_offset + 1) = '0' + (command/ 1 % 10);
     if (sprintf_offset[0] == '0')
         sprintf_offset[0] = ' '; /* Leading 0's may confuse decimal w/ octal. */
-    MessageBox (NULL, buff, "Audio HLE Error", MB_OK);
+    MessageBox(NULL, buff, PLUGIN_VERSION, MB_OK);
 }
 extern u16 AudioInBuffer;		// 0x0000(T8)
 extern u16 AudioOutBuffer;		// 0x0002(T8)

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -13,9 +13,16 @@
 #include "audiohle.h"
 
 static void SPNOOP () {
-	char buff[0x100];
-	sprintf (buff, "Unknown/Unimplemented Audio Command %i in ABI 3", k0 >> 24);
-	MessageBox (NULL, buff, PLUGIN_VERSION, MB_OK);
+    static char buff[] = "Unknown/Unimplemented Audio Command %i in ABI 3";
+    char * sprintf_offset;
+    const u8 command = (unsigned char)((k0 & 0xFF000000ul) >> 24);
+
+    sprintf_offset = strchr(&buff[0], '%'); /* Overwrite "%i" with decimal. */
+    *(sprintf_offset + 0) = '0' + (command/10 % 10);
+    *(sprintf_offset + 1) = '0' + (command/ 1 % 10);
+    if (sprintf_offset[0] == '0')
+        sprintf_offset[0] = ' '; /* Leading 0's may confuse decimal w/ octal. */
+    MessageBox (NULL, buff, PLUGIN_VERSION, MB_OK);
 }
 
 extern u16 ResampleLUT [0x200];

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -22,7 +22,7 @@ static void SPNOOP () {
     *(sprintf_offset + 1) = '0' + (command/ 1 % 10);
     if (sprintf_offset[0] == '0')
         sprintf_offset[0] = ' '; /* Leading 0's may confuse decimal w/ octal. */
-    MessageBox (NULL, buff, PLUGIN_VERSION, MB_OK);
+    MessageBox(NULL, buff, PLUGIN_VERSION, MB_OK);
 }
 
 extern u16 ResampleLUT [0x200];

--- a/AziAudio/WaveOut.cpp
+++ b/AziAudio/WaveOut.cpp
@@ -32,7 +32,11 @@ void WaveOut::BeginWaveOut(char *filename, WORD channels, WORD bitsPerSample, DW
 	memcpy(header.Subchunk2ID,"data",4);
 	header.Subchunk2Size=0; // TODO at EndWaveOut
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+	fopen_s(&waveoutput, filename, "wb");
+#else
 	waveoutput = fopen(filename, "wb");
+#endif
 	fwrite(&header, sizeof(WaveHeader), 1, waveoutput);
 	datasize = 0;
 }

--- a/AziAudio/WaveOut.cpp
+++ b/AziAudio/WaveOut.cpp
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include "WaveOut.h"	
 
-void WaveOut::BeginWaveOut(char *filename, WORD channels, DWORD bitsPerSample, DWORD sampleRate)
+void WaveOut::BeginWaveOut(char *filename, WORD channels, WORD bitsPerSample, DWORD sampleRate)
 {
 	if (waveoutput != NULL) return;
 	// Clear header

--- a/AziAudio/WaveOut.h
+++ b/AziAudio/WaveOut.h
@@ -42,7 +42,7 @@ protected:
 	FILE *waveoutput;
 	DWORD datasize;
 public:
-	void BeginWaveOut(char *filename, WORD channels, DWORD bitsPerSample, DWORD sampleRate);
+	void BeginWaveOut(char *filename, WORD channels, WORD bitsPerSample, DWORD sampleRate);
 	void EndWaveOut();
 	void WriteData (unsigned char*data, DWORD size);
 };


### PR DESCRIPTION
All the warning messages when compiling should be fixed now.

At times I'm sure some warnings are better left unfixed, than fixed, but I think with what few cases (only seemed to be 4 warnings left in this entire source) were left, it seemed straightforward enough to tackle.