### PR TITLE
I don't always clamp, but when i do...

### DIFF
--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -345,14 +345,10 @@ void ENVMIXER () {
 		AuxL  = (((s64)Wet*2 * (s64)(LAcc>>16)) + 0x8000) >> 16; 
 		AuxR  = (((s64)Wet*2 * (s64)(RAcc>>16)) + 0x8000) >> 16;*/
 /*
-		if (MainL>32767) MainL = 32767;
-		else if (MainL<-32768) MainL = -32768;
-		if (MainR>32767) MainR = 32767;
-		else if (MainR<-32768) MainR = -32768;
-		if (AuxL>32767) AuxL = 32767;
-		else if (AuxL<-32768) AuxR = -32768;
-		if (AuxR>32767) AuxR = 32767;
-		else if (AuxR<-32768) AuxR = -32768;*/
+		MainL = pack_signed(MainL);
+		MainR = pack_signed(MainR);
+		AuxL = pack_signed(AuxL);
+		AuxR = pack_signed(AuxR);*/
 		/*
 		MainR = (Dry * RTrg + 0x10000) >> 15;
 		MainL = (Dry * LTrg + 0x10000) >> 15;
@@ -366,11 +362,8 @@ void ENVMIXER () {
 
 		a1=((s64)(((s64)a1*0xfffe)+((s64)i1*MainL*2)+0x8000)>>16);*/
 
-		if(o1>32767) o1=32767;
-		else if(o1<-32768) o1=-32768;
-
-		if(a1>32767) a1=32767;
-		else if(a1<-32768) a1=-32768;
+		o1 = pack_signed(o1);
+		a1 = pack_signed(a1);
 
 		out[ptr^1]=o1;
 		aux1[ptr^1]=a1;
@@ -380,12 +373,9 @@ void ENVMIXER () {
 			//a3=((s64)(((s64)a3*0xfffe)+((s64)i1*AuxL*2)+0x8000)>>16);
 			a2+=(/*(a2*0x7fff)+*/(i1*AuxR)+0x4000)>>15;
 			a3+=(/*(a3*0x7fff)+*/(i1*AuxL)+0x4000)>>15;
-			
-			if(a2>32767) a2=32767;
-			else if(a2<-32768) a2=-32768;
 
-			if(a3>32767) a3=32767;
-			else if(a3<-32768) a3=-32768;
+			a2 = pack_signed(a2);
+			a3 = pack_signed(a3);
 
 			aux2[ptr^1]=a2;
 			aux3[ptr^1]=a3;
@@ -460,17 +450,10 @@ void ENVMIXERo () { // Borrowed from RCP...
 		a1=((a1*0x7fff)+(i1*MainL)+0x10000)>>15;
 		a3=((a3*0x7fff)+(i1*AuxL)+0x8000)>>16;
 
-		if(o1>32767) o1=32767;
-		else if(o1<-32768) o1=-32768;
-
-		if(a1>32767) a1=32767;
-		else if(a1<-32768) a1=-32768;
-
-		if(a2>32767) a2=32767;
-		else if(a2<-32768) a2=-32768;
-
-		if(a3>32767) a3=32767;
-		else if(a3<-32768) a3=-32768;
+		o1 = pack_signed(o1);
+		a1 = pack_signed(a1);
+		a2 = pack_signed(a2);
+		a3 = pack_signed(a3);
 
 		*(out++)=o1;
 		*(aux1++)=a1;
@@ -548,8 +531,7 @@ void RESAMPLE () {
 		temp = ((s32)*(s16*)(src+((srcPtr+3)^1))*((s32)((s16)lut[3])));
 		accum += (s32)(temp >> 15);
 
-		if (accum > 32767) accum = 32767;
-		if (accum < -32768) accum = -32768;
+		accum = pack_signed(accum);
 
 		dst[dstPtr^1] = (s16)(accum);
 		dstPtr++;
@@ -778,8 +760,7 @@ void ADPCM () { // Work in progress! :)
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 		}
 		l1=a[6];
@@ -848,8 +829,7 @@ void ADPCM () { // Work in progress! :)
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 		}
 		l1=a[6];
@@ -979,11 +959,7 @@ void MIXER () { // Fixed a sign issue... 03-14-01
 	for (int x=0; x < AudioCount; x+=2) { // I think I can do this a lot easier 
 		temp = (*(s16 *)(BufferSpace+dmemin+x) * gain) >> 15;
 		temp += *(s16 *)(BufferSpace+dmemout+x);
-			
-		if ((s32)temp > 32767) 
-			temp = 32767;
-		if ((s32)temp < -32768) 
-			temp = -32768;
+		temp = pack_signed((s32)temp);
 
 		*(u16 *)(BufferSpace+dmemout+x) = (u16)(temp & 0xFFFF);
 	}
@@ -1032,10 +1008,7 @@ void MIXER () { // Fixed a sign issue... 03-14-01
 		temp += ((*(s16 *)(BufferSpace+dmemin+x) * (s64)((s16)gain*2))) & 0xFFFFFFFFFFFF;
 			
 		temp = (s32)(temp >> 16);
-		if ((s32)temp > 32767) 
-			temp = 32767;
-		if ((s32)temp < -32768) 
-			temp = -32768;
+		temp = pack_signed((s32)temp);
 
 		*(u16 *)(BufferSpace+dmemout+x) = (u16)(temp & 0xFFFF);
 	}

--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -417,8 +417,7 @@ void RESAMPLE2 () {
 			src[(srcPtr+x)^1] = 0;//*(u16 *)(rdram+((addy+x)^2));
 	}
 
-//	if ((Flags & 0x2))
-//		__asm int 3;
+//	assert((Flags & 0x2) == 0);
 
 	for(int i=0;i < ((AudioCount+0xf)&0xFFF0)/2;i++)	{
 		location = (((Accum * 0x40) >> 0x10) * 8);
@@ -515,7 +514,7 @@ void ENVMIXER2 () {
 
 	s16 v2[8];
 
-	//__asm int 3;
+	//assert(0);
 
 	buffs3 = (s16 *)(BufferSpace + ((k0 >> 0x0c)&0x0ff0));
 	bufft6 = (s16 *)(BufferSpace + ((t9 >> 0x14)&0x0ff0));

--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -266,8 +266,7 @@ void ADPCM2 () { // Verified to be 100% Accurate...
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 		}
 		l1=a[6];
@@ -336,8 +335,7 @@ void ADPCM2 () { // Verified to be 100% Accurate...
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 		}
 		l1=a[6];
@@ -382,11 +380,7 @@ void MIXER2 () { // Needs accuracy verification...
 
 		temp = (*(s16 *)(BufferSpace+dmemin+x) * gain) >> 16;
 		temp += *(s16 *)(BufferSpace+dmemout+x);
-			
-		if ((s32)temp > 32767) 
-			temp = 32767;
-		if ((s32)temp < -32768) 
-			temp = -32768;
+		temp = pack_signed((s32)temp);
 
 		*(u16 *)(BufferSpace+dmemout+x) = (u16)(temp & 0xFFFF);
 	}
@@ -443,8 +437,7 @@ void RESAMPLE2 () {
 		temp = ((s32)*(s16*)(src+((srcPtr+3)^1))*((s32)((s16)lut[3])));
 		accum += (s32)(temp >> 15);
 
-		if (accum > 32767) accum = 32767;
-		if (accum < -32768) accum = -32768;
+		accum = pack_signed(accum);
 
 		dst[dstPtr^1] = (s16)(accum);
 		dstPtr++;
@@ -554,26 +547,26 @@ void ENVMIXER2 () {
 			vec9  = (s16)(((s32)buffs3[x^1] * (u32)env[0]) >> 0x10) ^ v2[0];
 			vec10 = (s16)(((s32)buffs3[x^1] * (u32)env[2]) >> 0x10) ^ v2[1];
 			temp = bufft6[x^1] + vec9;
-			if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+			temp = pack_signed(temp);
 			bufft6[x^1] = temp;
 			temp = bufft7[x^1] + vec10;
-			if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+			temp = pack_signed(temp);
 			bufft7[x^1] = temp;
 			vec9  = (s16)(((s32)vec9  * (u32)env[4]) >> 0x10) ^ v2[2];
 			vec10 = (s16)(((s32)vec10 * (u32)env[4]) >> 0x10) ^ v2[3];
 			if (k0 & 0x10) {
 				temp = buffs0[x^1] + vec10;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs0[x^1] = temp;
 				temp = buffs1[x^1] + vec9;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs1[x^1] = temp;
 			} else {
 				temp = buffs0[x^1] + vec9;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs0[x^1] = temp;
 				temp = buffs1[x^1] + vec10;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs1[x^1] = temp;
 			}
 		}
@@ -583,26 +576,26 @@ void ENVMIXER2 () {
 			vec9  = (s16)(((s32)buffs3[x^1] * (u32)env[1]) >> 0x10) ^ v2[0];
 			vec10 = (s16)(((s32)buffs3[x^1] * (u32)env[3]) >> 0x10) ^ v2[1];
 			temp = bufft6[x^1] + vec9;
-			if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+			temp = pack_signed(temp);
 			bufft6[x^1] = temp;
 			temp = bufft7[x^1] + vec10;
-			if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+			temp = pack_signed(temp);
 			bufft7[x^1] = temp;
 			vec9  = (s16)(((s32)vec9  * (u32)env[5]) >> 0x10) ^ v2[2];
 			vec10 = (s16)(((s32)vec10 * (u32)env[5]) >> 0x10) ^ v2[3];
 			if (k0 & 0x10) {
 				temp = buffs0[x^1] + vec10;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs0[x^1] = temp;
 				temp = buffs1[x^1] + vec9;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs1[x^1] = temp;
 			} else {
 				temp = buffs0[x^1] + vec9;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs0[x^1] = temp;
 				temp = buffs1[x^1] + vec10;
-				if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+				temp = pack_signed(temp);
 				buffs1[x^1] = temp;
 			}
 		}
@@ -721,7 +714,7 @@ void ADDMIXER () {
 	outp = (s16 *)(BufferSpace + OutBuffer);
 	for (int cntr = 0; cntr < Count; cntr+=2) {
 		temp = *outp + *inp;
-		if (temp > 32767)  temp = 32767; if (temp < -32768) temp = -32768;
+		temp = pack_signed(temp);
 		outp++;	inp++;
 	}
 }
@@ -740,8 +733,7 @@ void HILOGAIN () {
 		val = (s32)*src;
 		//tmp = ((val * (s32)hi) + ((u64)(val * lo) << 16) >> 16);
 		tmp = ((val * (s32)hi) >> 16) + (u32)(val * lo);
-		if ((s32)tmp > 32767) tmp = 32767;
-		else if ((s32)tmp < -32768) tmp = -32768;
+		tmp = pack_signed((s32)tmp);
 		*src = (s16)tmp;
 		src++;
 		cnt -= 2;

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -189,11 +189,8 @@ void ENVMIXER3 () {
 
 // ****************************************************************
 
-		if(o1>32767) o1=32767;
-		else if(o1<-32768) o1=-32768;
-
-		if(a1>32767) a1=32767;
-		else if(a1<-32768) a1=-32768;
+		o1 = pack_signed(o1);
+		a1 = pack_signed(a1);
 
 // ****************************************************************
 
@@ -211,11 +208,8 @@ void ENVMIXER3 () {
 			a2+=((i1*AuxL)+0x4000)>>15;
 			a3+=((i1*AuxR)+0x4000)>>15;
 			
-			if(a2>32767) a2=32767;
-			else if(a2<-32768) a2=-32768;
-
-			if(a3>32767) a3=32767;
-			else if(a3<-32768) a3=-32768;
+			a2 = pack_signed(a2);
+			a3 = pack_signed(a3);
 
 			aux2[y^1]=a2;
 			aux3[y^1]=a3;
@@ -343,14 +337,12 @@ void ENVMIXER3o () {
 		MainR = ((Dry * (RAcc>>16)) + 0x4000) >> 15; 
 		AuxL  = ((Wet * (LAcc>>16)) + 0x4000) >> 15; 
 		AuxR  = ((Wet * (RAcc>>16)) + 0x4000) >> 15;
-		/*if (MainL>32767) MainL = 32767;
-		else if (MainL<-32768) MainL = -32768;
-		if (MainR>32767) MainR = 32767;
-		else if (MainR<-32768) MainR = -32768;
-		if (AuxL>32767) AuxL = 32767;
-		else if (AuxL<-32768) AuxR = -32768;
-		if (AuxR>32767) AuxR = 32767;
-		else if (AuxR<-32768) AuxR = -32768;*/
+		/*
+		MainL = pack_signed(MainL);
+		MainR = pack_signed(MainR);
+		AuxL = pack_signed(AuxL);
+		AuxR = pack_signed(AuxR);
+		*/
 		/*
 		MainR = (Dry * RTrg + 0x10000) >> 15;
 		MainL = (Dry * LTrg + 0x10000) >> 15;
@@ -361,11 +353,8 @@ void ENVMIXER3o () {
 
 		a1+=(/*(a1*0x7fff)+*/(i1*MainL)+0x4000)>>15;
 
-		if(o1>32767) o1=32767;
-		else if(o1<-32768) o1=-32768;
-
-		if(a1>32767) a1=32767;
-		else if(a1<-32768) a1=-32768;
+		o1 = pack_signed(o1);
+		a1 = pack_signed(a1);
 
 		out[x^1]=o1;
 		aux1[x^1]=a1;
@@ -373,11 +362,8 @@ void ENVMIXER3o () {
 			a2+=(/*(a2*0x7fff)+*/(i1*AuxR)+0x4000)>>15;
 			a3+=(/*(a3*0x7fff)+*/(i1*AuxL)+0x4000)>>15;
 			
-			if(a2>32767) a2=32767;
-			else if(a2<-32768) a2=-32768;
-
-			if(a3>32767) a3=32767;
-			else if(a3<-32768) a3=-32768;
+			a2 = pack_signed(a2);
+			a3 = pack_signed(a3);
 
 			aux2[x^1]=a2;
 			aux3[x^1]=a3;
@@ -447,17 +433,10 @@ void ENVMIXER3 () { // Borrowed from RCP...
 		a1=((a1*0x7fff)+(i1*MainL)+0x10000)>>15;
 		a3=((a3*0x7fff)+(i1*AuxL)+0x8000)>>16;
 
-		if(o1>32767) o1=32767;
-		else if(o1<-32768) o1=-32768;
-
-		if(a1>32767) a1=32767;
-		else if(a1<-32768) a1=-32768;
-
-		if(a2>32767) a2=32767;
-		else if(a2<-32768) a2=-32768;
-
-		if(a3>32767) a3=32767;
-		else if(a3<-32768) a3=-32768;
+		o1 = pack_signed(o1);
+		a1 = pack_signed(a1);
+		a2 = pack_signed(a2);
+		a3 = pack_signed(a3);
 
 		*(out++)=o1;
 		*(aux1++)=a1;
@@ -490,11 +469,7 @@ void MIXER3 () { // Needs accuracy verification...
 	for (int x=0; x < 0x170; x+=2) { // I think I can do this a lot easier 
 		temp = (*(s16 *)(BufferSpace+dmemin+x) * gain) >> 16;
 		temp += *(s16 *)(BufferSpace+dmemout+x);
-			
-		if ((s32)temp > 32767) 
-			temp = 32767;
-		if ((s32)temp < -32768) 
-			temp = -32768;
+		temp = pack_signed((s32)temp);
 
 		*(u16 *)(BufferSpace+dmemout+x) = (u16)(temp & 0xFFFF);
 	}
@@ -725,8 +700,7 @@ void ADPCM3 () { // Verified to be 100% Accurate...
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 			//*(out+j)=a[j^1];
 		}
@@ -797,8 +771,7 @@ void ADPCM3 () { // Verified to be 100% Accurate...
 		for(j=0;j<8;j++)
 		{
 			a[j^1]>>=11;
-			if(a[j^1]>32767) a[j^1]=32767;
-			else if(a[j^1]<-32768) a[j^1]=-32768;
+			a[j^1] = pack_signed(a[j^1]);
 			*(out++)=a[j^1];
 			//*(out+j+0x1f8)=a[j^1];
 		}
@@ -871,36 +844,31 @@ void RESAMPLE3 () {
 		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
 		else temp = (temp^0x8000);
 		temp = (s32)(temp >> 16);
-		if ((s32)temp > 32767) temp = 32767;
-		if ((s32)temp < -32768) temp = -32768;
+		temp = pack_signed((s32)temp);
 		accum = (s32)(s16)temp;
 
 		temp = ((s64)*(s16*)(src+((srcPtr+1)^1))*((s64)((s16)lut[1]<<1)));
 		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
 		else temp = (temp^0x8000);
 		temp = (s32)(temp >> 16);
-		if ((s32)temp > 32767) temp = 32767;
-		if ((s32)temp < -32768) temp = -32768;
+		temp = pack_signed((s32)temp);
 		accum += (s32)(s16)temp;
 
 		temp = ((s64)*(s16*)(src+((srcPtr+2)^1))*((s64)((s16)lut[2]<<1)));
 		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
 		else temp = (temp^0x8000);
 		temp = (s32)(temp >> 16);
-		if ((s32)temp > 32767) temp = 32767;
-		if ((s32)temp < -32768) temp = -32768;
+		temp = pack_signed((s32)temp);
 		accum += (s32)(s16)temp;
 
 		temp = ((s64)*(s16*)(src+((srcPtr+3)^1))*((s64)((s16)lut[3]<<1)));
 		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
 		else temp = (temp^0x8000);
 		temp = (s32)(temp >> 16);
-		if ((s32)temp > 32767) temp = 32767;
-		if ((s32)temp < -32768) temp = -32768;
+		temp = pack_signed((s32)temp);
 		accum += (s32)(s16)temp;*/
 
-		if (accum > 32767) accum = 32767;
-		if (accum < -32768) accum = -32768;
+		accum = pack_signed(accum);
 
 		dst[dstPtr^1] = (s16)(accum);
 		dstPtr++;

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -569,20 +569,16 @@ void InnerLoop () {
 				hi1 = (int)hi1 >> 0x10;
 				for (i = 0; i < 8; i++) {
 					// v0
-					v = (*(s16 *)(mp3data+((tmp-0x40)^2)) * hi0);
-					if (v > 32767) v = 32767; else if (v < -32767) v = -32767;
+					v = pack_signed(*(s16 *)(mp3data+((tmp-0x40)^2)) * hi0);
 					*(s16 *)((u8 *)mp3data+((tmp-0x40)^2)) = (s16)v;
 					// v17
-					v = (*(s16 *)(mp3data+((tmp-0x30)^2)) * hi0);
-					if (v > 32767) v = 32767; else if (v < -32767) v = -32767;
+					v = pack_signed(*(s16 *)(mp3data+((tmp-0x30)^2)) * hi0);
 					*(s16 *)((u8 *)mp3data+((tmp-0x30)^2)) = (s16)v;
 					// v2
-					v = (*(s16 *)(mp3data+((tmp-0x1E)^2)) * hi1);
-					if (v > 32767) v = 32767; else if (v < -32767) v = -32767;
+					v = pack_signed(*(s16 *)(mp3data+((tmp-0x1E)^2)) * hi1);
 					*(s16 *)((u8 *)mp3data+((tmp-0x1E)^2)) = (s16)v;
 					// v4
-					v = (*(s16 *)(mp3data+((tmp-0xE)^2)) * hi1);
-					if (v > 32767) v = 32767; else if (v < -32767) v = -32767;
+					v = pack_signed(*(s16 *)(mp3data+((tmp-0x0E)^2)) * hi1);
 					*(s16 *)((u8 *)mp3data+((tmp-0xE)^2)) = (s16)v;
 					tmp += 2;
 				}

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -562,10 +562,9 @@ void InnerLoop () {
 				s32 hi1 = mult4;
 				s32 v;
 				/*
-				if (hi0 & 0xffff)
-					__asm int 3; 
-				if (hi1 & 0xffff)
-					__asm int 3;*/
+				assert((hi0 & 0xffff) == 0);
+				assert((hi1 & 0xffff) == 0);
+				*/
 				hi0 = (int)hi0 >> 0x10;
 				hi1 = (int)hi1 >> 0x10;
 				for (i = 0; i < 8; i++) {

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -246,7 +246,7 @@ void (*ABIUnknown [0x20])() = { // Unknown ABI
 };
 
 #ifndef PREFER_MACRO_FUNCTIONS
-inline s32 sats_over(s32 slice)
+INLINE s32 sats_over(s32 slice)
 {
 #ifdef TWOS_COMPLEMENT_NEGATION
     s32 adder, mask;
@@ -262,7 +262,7 @@ inline s32 sats_over(s32 slice)
     return (slice);
 #endif
 }
-inline s32 sats_under(s32 slice)
+INLINE s32 sats_under(s32 slice)
 {
 #ifdef TWOS_COMPLEMENT_NEGATION
     s32 adder, mask;
@@ -278,7 +278,7 @@ inline s32 sats_under(s32 slice)
     return (slice);
 #endif
 }
-inline s32 satu_over(s32 slice)
+INLINE s32 satu_over(s32 slice)
 {
 #ifdef TWOS_COMPLEMENT_NEGATION
     s32 adder, mask;
@@ -294,7 +294,7 @@ inline s32 satu_over(s32 slice)
     return (slice);
 #endif
 }
-inline s32 satu_under(s32 slice)
+INLINE s32 satu_under(s32 slice)
 {
 #ifdef TWOS_COMPLEMENT_NEGATION
     s32 adder, mask;
@@ -310,7 +310,7 @@ inline s32 satu_under(s32 slice)
 #endif
 }
 
-inline s16 pack_signed(s32 slice)
+INLINE s16 pack_signed(s32 slice)
 {
 #ifdef SSE2_SUPPORT
     __m128i xmm;
@@ -327,7 +327,7 @@ inline s16 pack_signed(s32 slice)
     return (s16)(result & 0x0000FFFFul);
 #endif
 }
-inline u16 pack_unsigned(s32 slice)
+INLINE u16 pack_unsigned(s32 slice)
 {
     s32 result;
 
@@ -337,7 +337,7 @@ inline u16 pack_unsigned(s32 slice)
     return (u16)(result & 0x0000FFFFul);
 }
 
-inline void vsats128(s16* vd, s32* vs)
+INLINE void vsats128(s16* vd, s32* vs)
 {
 #ifdef SSE2_SUPPORT
     __m128i xmm;
@@ -352,14 +352,14 @@ inline void vsats128(s16* vd, s32* vs)
         vd[i] = pack_signed(vs[i]);
 #endif
 }
-inline void vsatu128(u16* vd, s32* vs)
+INLINE void vsatu128(u16* vd, s32* vs)
 {
     register size_t i;
 
     for (i = 0; i < 4; i++)
         vd[i] = pack_unsigned(vs[i]);
 }
-inline void vsats64 (s16* vd, s32* vs)
+INLINE void vsats64 (s16* vd, s32* vs)
 {
 #ifdef SSE2_SUPPORT
     __m64 mmx;
@@ -375,7 +375,7 @@ inline void vsats64 (s16* vd, s32* vs)
         vd[i] = pack_signed(vs[i]);
 #endif
 }
-inline void vsatu64 (u16* vd, s32* vs)
+INLINE void vsatu64 (u16* vd, s32* vs)
 {
     register size_t i;
 

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -81,6 +81,24 @@ extern u32 s0, s1, s2, s3, s4, s5, s6, s7;
 extern u32 t8, t9, k0, k1, gp, sp, s8, ra;
 */
 
+/*
+ * Include the SSE2 headers if MSVC is set to target SSE2 in code generation.
+ */
+#if defined(_M_IX86_FP) && (_M_IX86_FP >= 2)
+#include <emmintrin.h>
+#endif
+
+/* ... or if compiled with the right preprocessor token on other compilers */
+#ifdef SSE2_SUPPORT
+#include <emmintrin.h>
+#endif
+
+/* The SSE1 and SSE2 headers always define these macro functions: */
+#undef SSE2_SUPPORT
+#if defined(_MM_SHUFFLE) && defined(_MM_SHUFFLE2)
+#define SSE2_SUPPORT
+#endif
+
 #if 0
 #define PREFER_MACRO_FUNCTIONS
 #endif

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -121,18 +121,18 @@ extern u32 t8, t9, k0, k1, gp, sp, s8, ra;
 #define satu_over(slice)        (((slice) < 0x0000) ? 0x0000U : (slice))
 #define satu_under(slice)       (((slice) > 0xFFFF) ? 0xFFFFU : (slice))
 #else
-extern inline s32 sats_over(s32 slice);
-extern inline s32 sats_under(s32 slice);
-extern inline s32 satu_over(s32 slice);
-extern inline s32 satu_under(s32 slice);
+extern INLINE s32 sats_over(s32 slice);
+extern INLINE s32 sats_under(s32 slice);
+extern INLINE s32 satu_over(s32 slice);
+extern INLINE s32 satu_under(s32 slice);
 #endif
 
 #ifdef PREFER_MACRO_FUNCTIONS
 #define pack_signed(slice)      sats_over(sats_under(slice))
 #define pack_unsigned(slice)    satu_over(satu_under(slice))
 #else
-extern inline s16 pack_signed(s32 slice);
-extern inline u16 pack_unsigned(s32 slice);
+extern INLINE s16 pack_signed(s32 slice);
+extern INLINE u16 pack_unsigned(s32 slice);
 #endif
 
 #ifdef PREFER_MACRO_FUNCTIONS
@@ -147,10 +147,10 @@ vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); }
 #define vsatu64(vd, vs) {       \
 vd[0] = pack_unsigned(vs[0]); vd[1] = pack_unsigned(vs[1]); }
 #else
-extern inline void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
-extern inline void vsatu128(u16* vd, s32* vs);
-extern inline void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
-extern inline void vsatu64 (u16* vd, s32* vs);
+extern INLINE void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
+extern INLINE void vsatu128(u16* vd, s32* vs);
+extern INLINE void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
+extern INLINE void vsatu64 (u16* vd, s32* vs);
 #endif
 
 /*

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -80,3 +80,69 @@ extern u32 t0, t1, t2, t3, t4, t5, t6, t7;
 extern u32 s0, s1, s2, s3, s4, s5, s6, s7;
 extern u32 t8, t9, k0, k1, gp, sp, s8, ra;
 */
+
+#if 0
+#define PREFER_MACRO_FUNCTIONS
+#endif
+
+/*
+ * RSP hardware has two types of saturated arithmetic:
+ *     1.  signed clamping from 32- to 16-bit elements
+ *     2.  unsigned clamping from 32- to 16-bit elements
+ *
+ * Accumulators are 48-bit, but only 32-bit-segment intervals at one time are
+ * involved in the clamp.  The upper and lower bounds for signed and unsigned
+ * clamping match the ANSI C language minimum requirements for the types
+ * `short` and `unsigned short`:  -32768 <= x <= +32767 and 0 <= x <= +65535.
+ *
+ * A "slice" is an off-set portion of the accumulator:  high, middle, or low.
+ */
+#ifdef PREFER_MACRO_FUNCTIONS
+#define sats_over(slice)        (((slice) > +32767) ? +32767  : (slice))
+#define sats_under(slice)       (((slice) < -32768) ? -32768  : (slice))
+#define satu_over(slice)        (((slice) < 0x0000) ? 0x0000U : (slice))
+#define satu_under(slice)       (((slice) > 0xFFFF) ? 0xFFFFU : (slice))
+#else
+extern inline s32 sats_over(s32 slice);
+extern inline s32 sats_under(s32 slice);
+extern inline s32 satu_over(s32 slice);
+extern inline s32 satu_under(s32 slice);
+#endif
+
+#ifdef PREFER_MACRO_FUNCTIONS
+#define pack_signed(slice)      sats_over(sats_under(slice))
+#define pack_unsigned(slice)    satu_over(satu_under(slice))
+#else
+extern inline s16 pack_signed(s32 slice);
+extern inline u16 pack_unsigned(s32 slice);
+#endif
+
+#ifdef PREFER_MACRO_FUNCTIONS
+#define vsats128(vd, vs) {      \
+vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); \
+vd[2] = pack_signed(vs[2]); vd[3] = pack_signed(vs[3]); }
+#define vsatu128(vd, vs) {      \
+vd[0] = pack_unsigned(vs[0]); vd[1] = pack_unsigned(vs[1]); \
+vd[2] = pack_unsigned(vs[2]); vd[3] = pack_unsigned(vs[3]); }
+#define vsats64(vd, vs) {       \
+vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); }
+#define vsatu64(vd, vs) {       \
+vd[0] = pack_unsigned(vs[0]); vd[1] = pack_unsigned(vs[1]); }
+#else
+extern inline void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
+extern inline void vsatu128(u16* vd, s32* vs);
+extern inline void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
+extern inline void vsatu64 (u16* vd, s32* vs);
+#endif
+
+/*
+ * Basically, if we can prove that, on the C implementation in question:
+ *     1.  Integers are negative if all bits are set (or simply the MSB).
+ *     2.  Shifting a signed integer to the right shifts in the sign bit.
+ * ... then we are able to easily staticize [un-]signed clamping functions.
+ */
+#if (~0 < 0)
+#if ((~0 & ~1) >> 1 == ~0)
+#define TWOS_COMPLEMENT_NEGATION
+#endif
+#endif

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -22,6 +22,12 @@
 #define SEH_SUPPORTED
 #endif
 
+#if defined(_MSC_VER)
+#define INLINE          __inline
+#else
+#define INLINE
+#endif
+
 #ifndef XAUDIO_LIBRARIES_UNAVAILABLE
 #define USE_XAUDIO2
 #endif

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -14,6 +14,7 @@ mkdir Mupen64plusHLE
 set FLAGS_x86=-O3^
  -I%obj%/dx_mingw^
  -DXAUDIO_LIBRARIES_UNAVAILABLE^
+ -DSSE2_SUPPORT^
  -masm=intel^
  -msse2^
  -mstackrealign


### PR DESCRIPTION
...I like to have a central [macro/inline] function for doing it with SSE. :)

The performance may not necessarily be any better though, because right now all I did was install my `pack_signed` function throughout ABI1, ABI2, and ABI3.  Loading a 32-bit word to the low 128 bits of an XMM, doing a SIMD signed pack of the whole thing, just to store only one 32-bit result seems a bit costly.  However, it definitely is at least more static/fixed than saying `if (x < -32768) x = -32768; else if (x > 32767) x = 32767;` all the time.  The problem is that SSE instructions use more byte code...AziAudio.dll grew from 65.0 KB to 66.0 KB as a result of installing my function.

It goes back down again to 65.0 though if you enable the macro versions of my functions (instead of saying inline functions) though, which goes back to the original dynamic if/else algorithm of doing it.  So at least it's maintainable then.

Another solution (to get the DLL size back down, *plus* extra perf.) would be to start using the vector pack function I also installed:  `vsats128`, which finally does make use of the SSE2 large byte code size by doing 4 packs at once.  However the ABI code might become slightly less readable (or maybe more), because then you can't say o1/a1/a2/a3 all the time; you have to move everything to arrays.