### PR TITLE
MinGW build fixes for some old versions of Windows

### DIFF
--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -1,9 +1,9 @@
 @ECHO OFF
 TITLE MinGW Compiler Suite Invocation
 
-set MinGW=C:/MinGW
-set src=%CD%/AziAudio
-set obj=%CD%/gccbuild
+set MinGW=C:\MinGW
+set src=%CD%\AziAudio
+set obj=%CD%\gccbuild
 
 if not exist gccbuild (
 mkdir gccbuild
@@ -12,65 +12,65 @@ mkdir Mupen64plusHLE
 )
 
 set FLAGS_x86=-O3^
- -I%obj%/dx_mingw^
+ -I%obj%\dx_mingw^
  -DXAUDIO_LIBRARIES_UNAVAILABLE^
  -masm=intel^
  -msse2^
  -mstackrealign
 set C_FLAGS=%FLAGS_X86%
 
-cd %MinGW%/bin
+cd %MinGW%\bin
 
 ECHO Compiling sources...
-gcc -o %obj%/Mupen64plusHLE/audio.asm           %src%/Mupen64plusHLE/audio.c          -S %C_FLAGS%
-gcc -o %obj%/Mupen64plusHLE/memory.asm          %src%/Mupen64plusHLE/memory.c         -S %C_FLAGS%
-gcc -o %obj%/Mupen64plusHLE/Mupen64Support.asm  %src%/Mupen64plusHLE/Mupen64Support.c -S %C_FLAGS%
-gcc -o %obj%/Mupen64plusHLE/musyx.asm           %src%/Mupen64plusHLE/musyx.c          -S %C_FLAGS%
-g++ -o %obj%/ABI1.asm                   %src%/ABI1.cpp                  -S %C_FLAGS%
-g++ -o %obj%/ABI2.asm                   %src%/ABI2.cpp                  -S %C_FLAGS%
-g++ -o %obj%/ABI3.asm                   %src%/ABI3.cpp                  -S %C_FLAGS%
-g++ -o %obj%/ABI3mp3.asm                %src%/ABI3mp3.cpp               -S %C_FLAGS%
-g++ -o %obj%/DirectSoundDriver.asm      %src%/DirectSoundDriver.cpp     -S %C_FLAGS%
-g++ -o %obj%/HLEMain.asm                %src%/HLEMain.cpp               -S %C_FLAGS%
-g++ -o %obj%/main.asm                   %src%/main.cpp                  -S %C_FLAGS%
-g++ -o %obj%/SafeABI.asm                %src%/SafeABI.cpp               -S %C_FLAGS%
-g++ -o %obj%/WaveOut.asm                %src%/WaveOut.cpp               -S %C_FLAGS%
-g++ -o %obj%/XAudio2SoundDriver.asm     %src%/XAudio2SoundDriver.cpp    -S %C_FLAGS%
+gcc -o %obj%\Mupen64plusHLE\audio.asm           %src%\Mupen64plusHLE\audio.c          -S %C_FLAGS%
+gcc -o %obj%\Mupen64plusHLE\memory.asm          %src%\Mupen64plusHLE\memory.c         -S %C_FLAGS%
+gcc -o %obj%\Mupen64plusHLE\Mupen64Support.asm  %src%\Mupen64plusHLE\Mupen64Support.c -S %C_FLAGS%
+gcc -o %obj%\Mupen64plusHLE\musyx.asm           %src%\Mupen64plusHLE\musyx.c          -S %C_FLAGS%
+g++ -o %obj%\ABI1.asm                   %src%\ABI1.cpp                  -S %C_FLAGS%
+g++ -o %obj%\ABI2.asm                   %src%\ABI2.cpp                  -S %C_FLAGS%
+g++ -o %obj%\ABI3.asm                   %src%\ABI3.cpp                  -S %C_FLAGS%
+g++ -o %obj%\ABI3mp3.asm                %src%\ABI3mp3.cpp               -S %C_FLAGS%
+g++ -o %obj%\DirectSoundDriver.asm      %src%\DirectSoundDriver.cpp     -S %C_FLAGS%
+g++ -o %obj%\HLEMain.asm                %src%\HLEMain.cpp               -S %C_FLAGS%
+g++ -o %obj%\main.asm                   %src%\main.cpp                  -S %C_FLAGS%
+g++ -o %obj%\SafeABI.asm                %src%\SafeABI.cpp               -S %C_FLAGS%
+g++ -o %obj%\WaveOut.asm                %src%\WaveOut.cpp               -S %C_FLAGS%
+g++ -o %obj%\XAudio2SoundDriver.asm     %src%\XAudio2SoundDriver.cpp    -S %C_FLAGS%
 
 ECHO Assembling compiled sources...
-as -o %obj%/ABI1.o                          %obj%/ABI1.asm
-as -o %obj%/ABI2.o                          %obj%/ABI2.asm
-as -o %obj%/ABI3.o                          %obj%/ABI3.asm
-as -o %obj%/ABI3mp3.o                       %obj%/ABI3mp3.asm
-as -o %obj%/DirectSoundDriver.o             %obj%/DirectSoundDriver.asm
-as -o %obj%/HLEMain.o                       %obj%/HLEMain.asm
-as -o %obj%/main.o                          %obj%/main.asm
-as -o %obj%/SafeABI.o                       %obj%/SafeABI.asm
-as -o %obj%/WaveOut.o                       %obj%/WaveOut.asm
-as -o %obj%/XAudio2SoundDriver.o            %obj%/XAudio2SoundDriver.asm
+as -o %obj%\ABI1.o                          %obj%\ABI1.asm
+as -o %obj%\ABI2.o                          %obj%\ABI2.asm
+as -o %obj%\ABI3.o                          %obj%\ABI3.asm
+as -o %obj%\ABI3mp3.o                       %obj%\ABI3mp3.asm
+as -o %obj%\DirectSoundDriver.o             %obj%\DirectSoundDriver.asm
+as -o %obj%\HLEMain.o                       %obj%\HLEMain.asm
+as -o %obj%\main.o                          %obj%\main.asm
+as -o %obj%\SafeABI.o                       %obj%\SafeABI.asm
+as -o %obj%\WaveOut.o                       %obj%\WaveOut.asm
+as -o %obj%\XAudio2SoundDriver.o            %obj%\XAudio2SoundDriver.asm
 
-as -o %obj%/Mupen64plusHLE/audio.o          %obj%/Mupen64plusHLE/audio.asm
-as -o %obj%/Mupen64plusHLE/memory.o         %obj%/Mupen64plusHLE/memory.asm
-as -o %obj%/Mupen64plusHLE/Mupen64Support.o %obj%/Mupen64plusHLE/Mupen64Support.asm
-as -o %obj%/Mupen64plusHLE/musyx.o          %obj%/Mupen64plusHLE/musyx.asm
+as -o %obj%\Mupen64plusHLE\audio.o          %obj%\Mupen64plusHLE\audio.asm
+as -o %obj%\Mupen64plusHLE\memory.o         %obj%\Mupen64plusHLE\memory.asm
+as -o %obj%\Mupen64plusHLE\Mupen64Support.o %obj%\Mupen64plusHLE\Mupen64Support.asm
+as -o %obj%\Mupen64plusHLE\musyx.o          %obj%\Mupen64plusHLE\musyx.asm
 ECHO.
 
 set OBJ_LIST=^
-%obj%/ABI1.o ^
-%obj%/ABI2.o ^
-%obj%/ABI3.o ^
-%obj%/ABI3mp3.o ^
-%obj%/DirectSoundDriver.o ^
-%obj%/HLEMain.o ^
-%obj%/main.o ^
-%obj%/SafeABI.o ^
-%obj%/WaveOut.o ^
-%obj%/XAudio2SoundDriver.o ^
-%obj%/Mupen64plusHLE/audio.o ^
-%obj%/Mupen64plusHLE/memory.o ^
-%obj%/Mupen64plusHLE/Mupen64Support.o ^
-%obj%/Mupen64plusHLE/musyx.o
+%obj%\ABI1.o ^
+%obj%\ABI2.o ^
+%obj%\ABI3.o ^
+%obj%\ABI3mp3.o ^
+%obj%\DirectSoundDriver.o ^
+%obj%\HLEMain.o ^
+%obj%\main.o ^
+%obj%\SafeABI.o ^
+%obj%\WaveOut.o ^
+%obj%\XAudio2SoundDriver.o ^
+%obj%\Mupen64plusHLE\audio.o ^
+%obj%\Mupen64plusHLE\memory.o ^
+%obj%\Mupen64plusHLE\Mupen64Support.o ^
+%obj%\Mupen64plusHLE\musyx.o
 
 ECHO Linking assembled object files...
-g++ -o %obj%/AziAudio.dll %OBJ_LIST% -ldsound --shared -s
+g++ -o %obj%\AziAudio.dll %OBJ_LIST% -ldsound --shared -s
 PAUSE

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -15,8 +15,7 @@ if not exist Mupen64plusHLE (
 mkdir Mupen64plusHLE
 )
 
-set FLAGS_x86=-O3^
- -I%obj%\dx_mingw^
+set FLAGS_x86=-I%obj%\dx_mingw^
  -DXAUDIO_LIBRARIES_UNAVAILABLE^
  -masm=intel^
  -msse2^
@@ -26,20 +25,20 @@ set C_FLAGS=%FLAGS_X86%
 cd %MinGW%\bin
 
 ECHO Compiling sources...
-gcc -o %obj%\Mupen64plusHLE\audio.asm           %src%\Mupen64plusHLE\audio.c          -S %C_FLAGS%
-gcc -o %obj%\Mupen64plusHLE\memory.asm          %src%\Mupen64plusHLE\memory.c         -S %C_FLAGS%
-gcc -o %obj%\Mupen64plusHLE\Mupen64Support.asm  %src%\Mupen64plusHLE\Mupen64Support.c -S %C_FLAGS%
-gcc -o %obj%\Mupen64plusHLE\musyx.asm           %src%\Mupen64plusHLE\musyx.c          -S %C_FLAGS%
-g++ -o %obj%\ABI1.asm                   %src%\ABI1.cpp                  -S %C_FLAGS%
-g++ -o %obj%\ABI2.asm                   %src%\ABI2.cpp                  -S %C_FLAGS%
-g++ -o %obj%\ABI3.asm                   %src%\ABI3.cpp                  -S %C_FLAGS%
-g++ -o %obj%\ABI3mp3.asm                %src%\ABI3mp3.cpp               -S %C_FLAGS%
-g++ -o %obj%\DirectSoundDriver.asm      %src%\DirectSoundDriver.cpp     -S %C_FLAGS%
-g++ -o %obj%\HLEMain.asm                %src%\HLEMain.cpp               -S %C_FLAGS%
-g++ -o %obj%\main.asm                   %src%\main.cpp                  -S %C_FLAGS%
-g++ -o %obj%\SafeABI.asm                %src%\SafeABI.cpp               -S %C_FLAGS%
-g++ -o %obj%\WaveOut.asm                %src%\WaveOut.cpp               -S %C_FLAGS%
-g++ -o %obj%\XAudio2SoundDriver.asm     %src%\XAudio2SoundDriver.cpp    -S %C_FLAGS%
+gcc -o %obj%\Mupen64plusHLE\audio.asm           %src%\Mupen64plusHLE\audio.c          -S %C_FLAGS% -O2
+gcc -o %obj%\Mupen64plusHLE\memory.asm          %src%\Mupen64plusHLE\memory.c         -S %C_FLAGS% -O2
+gcc -o %obj%\Mupen64plusHLE\Mupen64Support.asm  %src%\Mupen64plusHLE\Mupen64Support.c -S %C_FLAGS% -Os
+gcc -o %obj%\Mupen64plusHLE\musyx.asm           %src%\Mupen64plusHLE\musyx.c          -S %C_FLAGS% -O2
+g++ -o %obj%\ABI1.asm                   %src%\ABI1.cpp                  -S %C_FLAGS% -O2
+g++ -o %obj%\ABI2.asm                   %src%\ABI2.cpp                  -S %C_FLAGS% -O2
+g++ -o %obj%\ABI3.asm                   %src%\ABI3.cpp                  -S %C_FLAGS% -O2
+g++ -o %obj%\ABI3mp3.asm                %src%\ABI3mp3.cpp               -S %C_FLAGS% -O2
+g++ -o %obj%\DirectSoundDriver.asm      %src%\DirectSoundDriver.cpp     -S %C_FLAGS% -Os
+g++ -o %obj%\HLEMain.asm                %src%\HLEMain.cpp               -S %C_FLAGS% -Os
+g++ -o %obj%\main.asm                   %src%\main.cpp                  -S %C_FLAGS% -Os
+g++ -o %obj%\SafeABI.asm                %src%\SafeABI.cpp               -S %C_FLAGS% -Os
+g++ -o %obj%\WaveOut.asm                %src%\WaveOut.cpp               -S %C_FLAGS% -Os
+g++ -o %obj%\XAudio2SoundDriver.asm     %src%\XAudio2SoundDriver.cpp    -S %C_FLAGS% -Os
 
 ECHO Assembling compiled sources...
 as -o %obj%\ABI1.o                          %obj%\ABI1.asm

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -7,7 +7,11 @@ set obj=%CD%\gccbuild
 
 if not exist gccbuild (
 mkdir gccbuild
+)
+
 cd gccbuild
+
+if not exist Mupen64plusHLE (
 mkdir Mupen64plusHLE
 )
 

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -78,5 +78,5 @@ set OBJ_LIST=^
 
 ECHO Linking assembled object files...
 windres -i %src%\resource.rc --input-format=rc -o %obj%\res.res -O coff
-g++ -o %obj%\AziAudio.dll %OBJ_LIST% -ldsound --shared -s -Wl,--subsystem,windows
+g++ -o %obj%\AziAudio.dll %OBJ_LIST% -ldsound --shared -s -Wl,--subsystem,windows -shared -shared-libgcc
 PAUSE

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -73,8 +73,10 @@ set OBJ_LIST=^
 %obj%\Mupen64plusHLE\audio.o ^
 %obj%\Mupen64plusHLE\memory.o ^
 %obj%\Mupen64plusHLE\Mupen64Support.o ^
-%obj%\Mupen64plusHLE\musyx.o
+%obj%\Mupen64plusHLE\musyx.o ^
+%obj%\res.res
 
 ECHO Linking assembled object files...
-g++ -o %obj%\AziAudio.dll %OBJ_LIST% -ldsound --shared -s
+windres -i %src%\resource.rc --input-format=rc -o %obj%\res.res -O coff
+g++ -o %obj%\AziAudio.dll %OBJ_LIST% -ldsound --shared -s -Wl,--subsystem,windows
 PAUSE


### PR DESCRIPTION
Frank74 pointed out a few things I overlooked while making the build script.  I have not used XP in a while so wasn't aware until now.

The only unresolved thing is the GUI (and still no XAudio2)...I can't figure out why it's not working.  I did at least include the resource script in the linker config this time though, which I forgot to do last time.  I use the same config on my angrylion RDP plugin to get the GUI to work, but why it doesn't work here, I'm not sure.  May be different rules when linking C++ objects than C objects or something.