### PR TITLE
Prevent all the XAudio2 and DirectSound crashing when playing with no sound.

### DIFF
--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -385,7 +385,10 @@ BOOL DirectSoundDriver::Initialize(HWND hwnd) {
 
 	WaitForSingleObject(hMutex, INFINITE);
 
-	assert(!FAILED(hr = DirectSoundCreate8(NULL, &lpds, NULL)));
+	hr = DirectSoundCreate8(NULL, &lpds, NULL);
+//	assert(!FAILED(hr)); // This happens if there is no sound device.
+	if (FAILED(hr))
+		return -2;
 
 	if (FAILED(hr = IDirectSound_SetCooperativeLevel(lpds, hwnd, DSSCL_PRIORITY))) {
 		return -1;

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -183,9 +183,11 @@ void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
 	else if (Frequency < 15000 && Frequency > 10000) {
 		Frequency = 11025;
 	}*/
-	Setup();
-	g_source->SetSourceSampleRate(Frequency);
 	cacheSize = (Frequency / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
+
+	if (Setup() < 0) /* failed to apply a sound device */
+		return;
+	g_source->SetSourceSampleRate(Frequency);
 }
 
 DWORD XAudio2SoundDriver::AddBuffer(BYTE *start, DWORD length)


### PR DESCRIPTION
If you have no sound card or you're like me and accidentally yank your headphones unplugged every once in a while, you may have noticed that this plugin (either in DirectSound or XAudio2 mode) will crash at various points as early as when starting a ROM and as late as when shutting down the emulation thread.  This pull request is meant mostly to just address that.

It doesn't fix this issue still:
https://github.com/Azimer/AziAudio/issues/3

I know because I boot up Rogue Squadron, but it's hung up waiting for an interrupt from the audio interface.  This happens when sound is playing, but not when playing with my headphones unplugged.