### PR TITLE
Fix initialization problem in WDC with XA2

### DIFF
--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -190,7 +190,7 @@ void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
 
 DWORD XAudio2SoundDriver::AddBuffer(BYTE *start, DWORD length)
 {
-	if (length == 0) {
+	if (length == 0 || g_source == NULL) {
 		*AudioInfo.AI_STATUS_REG = 0;
 		*AudioInfo.MI_INTR_REG |= MI_INTR_AI;
 		AudioInfo.CheckInterrupts();


### PR DESCRIPTION
The crash occurred on line #230, when booting up WDC.