### PR TITLE
got 64-bit Debug builds working in VS2013 Community

### DIFF
--- a/AziAudio.sln
+++ b/AziAudio.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AziAudio", "AziAudio\AziAudio.vcxproj", "{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|Win32.Build.0 = Debug|Win32
+		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|x64.ActiveCfg = Debug|x64
+		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|x64.Build.0 = Debug|x64
 		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|Win32.ActiveCfg = Release|Win32
 		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|Win32.Build.0 = Release|Win32
+		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|x64.ActiveCfg = Release|x64
+		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -21,7 +29,20 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -34,7 +55,13 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -42,7 +69,16 @@
     <IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
     <LibraryPath>$(DXSDK_DIR)\Lib\x86;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(DXSDK_DIR)\Lib\x86;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>$(DXSDK_DIR)\Include;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>$(DXSDK_DIR)\Lib\x86;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+    <SourcePath>$(SourcePath)</SourcePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(DXSDK_DIR)\Include;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <LibraryPath>$(DXSDK_DIR)\Lib\x86;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
     <SourcePath>$(SourcePath)</SourcePath>
@@ -66,6 +102,26 @@
       </NoEntryPoint>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>dsound.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateMapFile>true</GenerateMapFile>
+      <SubSystem>NotSet</SubSystem>
+      <MinimumRequiredVersion>
+      </MinimumRequiredVersion>
+      <NoEntryPoint>
+      </NoEntryPoint>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -73,6 +129,27 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>dsound.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -158,7 +158,11 @@ INT_PTR CALLBACK ConfigProc(
 			short int userReq = LOWORD(wParam);
 			if (userReq == TB_ENDTRACK || userReq == TB_THUMBTRACK)
 			{
-				DWORD dwPosition  = SendMessage(GetDlgItem(hDlg,IDC_VOLUME   ), TBM_GETPOS, 0, 0);
+				LRESULT position;
+				DWORD dwPosition;
+
+				position = SendMessage(GetDlgItem(hDlg, IDC_VOLUME), TBM_GETPOS, 0, 0);
+				dwPosition = (position > 100) ? 100 : (DWORD)position;
 				snd.SetVolume(dwPosition);
 				if (!snd.configMute)
 				{

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -96,7 +96,7 @@ EXPORT void CALL DllAbout ( HWND hParent ){
 	MessageBox (hParent, "No About yet... ", "About Box", MB_OK);
 }
 
-BOOL CALLBACK ConfigProc(
+INT_PTR CALLBACK ConfigProc(
   HWND hDlg,  // handle to dialog box
   UINT uMsg,     // message
   WPARAM wParam, // first message parameter
@@ -184,9 +184,13 @@ BOOL CALLBACK ConfigProc(
 }
 
 
-EXPORT void CALL DllConfig ( HWND hParent ){
+EXPORT void CALL DllConfig(HWND hParent)
+{
+#if 0
+	MessageBox(hParent, "Nothing to config yet... ", "Config Box", MB_OK);
+#else
 	DialogBox(hInstance, MAKEINTRESOURCE(IDD_CONFIG), hParent, ConfigProc);
-//	MessageBox (hParent, "Nothing to config yet... ", "Config Box", MB_OK);
+#endif
 }
 
 EXPORT void CALL DllTest ( HWND hParent ){


### PR DESCRIPTION
I'm somewhat disappointed at how few changes it took to get it to build as a 64-bit DLL.  Turns out all I really needed to do was fix a function pointer mismatch in the resource dialog creation (first commit) and add the x64 stuff in the solution file to do the build (third commit).  There are 2 or 3 warnings left, but I fixed one of them as a demonstration (second commit).  I guess the easiest thing to do there seemed to be to factor in that the volume setting never exceeds a value of 100 decimal, so just clamp it to that and then force an explicit type-cast to DWORD anyway.  (Not sure that there was any better solution?)

Anyway what I'm stuck on is this linker error I'm getting in Release mode:
```
1>MSVCRT.lib(ti_inst.obj) : fatal error LNK1112: module machine type 'X86' conflicts with target machine type 'x64'
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
```
or, if I try to compile with the CRT statically linked (Multi-threaded EXE):
```
1>LIBCMT.lib(excptptr.obj) : fatal error LNK1112: module machine type 'X86' conflicts with target machine type 'x64'
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
```

??? Is this happening for anyone else?  It's happened both on VS2013 Professional at home and here on my laptop with VS2013 Community.  Doesn't make any sense--isn't this thing supposed to make sure the CRT library in x64 build modes matches the x64 configuration it created for me?  Debug builds however work perfectly.