### PR TITLE
Make compiling easier for people with Express/minimalist VS packages.

### DIFF
--- a/AziAudio/resource.rc
+++ b/AziAudio/resource.rc
@@ -7,7 +7,10 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winresrc.h>
+#ifndef IDC_STATIC
+#define IDC_STATIC      (-1)
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
This mostly is a repeat of an idea we've tested successfully with the Project64 repo:
https://github.com/project64/project64/pull/78

Back then I had learned from searching on the web that most people discovered that:
```c
#include "afxres.h"
```
... could be replaced with ...
```c
#include <WinResrc.h>
#define IDC_STATIC   (-1)
```

The missing afxres.h error is one you might find through searching online enough, but I remember Frank74 and I ran into it personally from the more lightweight installations of VS we did.  (I think there was supposed to be some optional checkbox when installing MSVC that would give you the afxres header.)  At any rate, the interwebz general consensus seems to be that the replacement is safe, and prevents the risk of compiler errors.  I did this change to get the plugin compiling in VS2013 Community back on my laptop which also lacked the header.