### PR TITLE
XAudio2SoundDriver: Get rid of undefined behavior

### DIFF
--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -235,7 +235,8 @@ DWORD XAudio2SoundDriver::AddBuffer(BYTE *start, DWORD length)
 	if (canPlay)
 		g_source->SubmitSourceBuffer(&xa2buff);
 
-	writeBuffer = ++writeBuffer % 10;
+	++writeBuffer;
+	writeBuffer %= 10;
 
 	if (bufferBytes < cacheSize || configForceSync == true)
 	{


### PR DESCRIPTION
Modifying a variable twice across a sequence point is considered undefined behavior.