### PR TITLE
Vectorize some nasty LWC2/transpose and MAC stuff in ABI_Filters.cpp.

### DIFF
--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -49,84 +49,84 @@ void FILTER2() {
 	inp2 = (short *)(BufferSpace + inPtr);
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
-			inp2[1] * lutt6[0] +
 			inp2[0] * lutt6[1] +
-			inp1[7] * lutt6[2] +
+			inp2[1] * lutt6[0] +
 			inp1[6] * lutt6[3] +
-			inp1[5] * lutt6[4] +
+			inp1[7] * lutt6[2] +
 			inp1[4] * lutt6[5] +
-			inp1[3] * lutt6[6] +
-			inp1[2] * lutt6[7]
+			inp1[5] * lutt6[4] +
+			inp1[2] * lutt6[7] +
+			inp1[3] * lutt6[6]
 		;
 		out1[1] =
-			inp1[6] * lutt6[0] +
 			inp2[1] * lutt6[1] +
-			inp1[4] * lutt6[2] +
+			inp1[6] * lutt6[0] +
 			inp1[7] * lutt6[3] +
-			inp1[2] * lutt6[4] +
+			inp1[4] * lutt6[2] +
 			inp1[5] * lutt6[5] +
-			inp1[0] * lutt6[6] +
-			inp1[3] * lutt6[7]
+			inp1[2] * lutt6[4] +
+			inp1[3] * lutt6[7] +
+			inp1[0] * lutt6[6]
 		;
 		out1[2] =
-			inp2[3] * lutt6[0] +
 			inp2[2] * lutt6[1] +
-			inp2[1] * lutt6[2] +
+			inp2[3] * lutt6[0] +
 			inp2[0] * lutt6[3] +
-			inp1[7] * lutt6[4] +
+			inp2[1] * lutt6[2] +
 			inp1[6] * lutt6[5] +
-			inp1[5] * lutt6[6] +
-			inp1[4] * lutt6[7]
+			inp1[7] * lutt6[4] +
+			inp1[4] * lutt6[7] +
+			inp1[5] * lutt6[6]
 		;
 		out1[3] =
-			inp2[0] * lutt6[0] +
 			inp2[3] * lutt6[1] +
-			inp1[6] * lutt6[2] +
+			inp2[0] * lutt6[0] +
 			inp2[1] * lutt6[3] +
-			inp1[4] * lutt6[4] +
+			inp1[6] * lutt6[2] +
 			inp1[7] * lutt6[5] +
-			inp1[2] * lutt6[6] +
-			inp1[5] * lutt6[7]
+			inp1[4] * lutt6[4] +
+			inp1[5] * lutt6[7] +
+			inp1[2] * lutt6[6]
 		;
 		out1[4] =
-			inp2[5] * lutt6[0] +
 			inp2[4] * lutt6[1] +
-			inp2[3] * lutt6[2] +
+			inp2[5] * lutt6[0] +
 			inp2[2] * lutt6[3] +
-			inp2[1] * lutt6[4] +
+			inp2[3] * lutt6[2] +
 			inp2[0] * lutt6[5] +
-			inp1[7] * lutt6[6] +
-			inp1[6] * lutt6[7]
+			inp2[1] * lutt6[4] +
+			inp1[6] * lutt6[7] +
+			inp1[7] * lutt6[6]
 		;
 		out1[5] =
-			inp2[2] * lutt6[0] +
 			inp2[5] * lutt6[1] +
-			inp2[0] * lutt6[2] +
+			inp2[2] * lutt6[0] +
 			inp2[3] * lutt6[3] +
-			inp1[6] * lutt6[4] +
+			inp2[0] * lutt6[2] +
 			inp2[1] * lutt6[5] +
-			inp1[4] * lutt6[6] +
-			inp1[7] * lutt6[7]
+			inp1[6] * lutt6[4] +
+			inp1[7] * lutt6[7] +
+			inp1[4] * lutt6[6]
 		;
 		out1[6] =
-			inp2[7] * lutt6[0] +
 			inp2[6] * lutt6[1] +
-			inp2[5] * lutt6[2] +
+			inp2[7] * lutt6[0] +
 			inp2[4] * lutt6[3] +
-			inp2[3] * lutt6[4] +
+			inp2[5] * lutt6[2] +
 			inp2[2] * lutt6[5] +
-			inp2[1] * lutt6[6] +
-			inp2[0] * lutt6[7]
+			inp2[3] * lutt6[4] +
+			inp2[0] * lutt6[7] +
+			inp2[1] * lutt6[6]
 		;
 		out1[7] =
-			inp2[4] * lutt6[0] +
 			inp2[7] * lutt6[1] +
-			inp2[2] * lutt6[2] +
+			inp2[4] * lutt6[0] +
 			inp2[5] * lutt6[3] +
-			inp2[0] * lutt6[4] +
+			inp2[2] * lutt6[2] +
 			inp2[3] * lutt6[5] +
-			inp1[6] * lutt6[6] +
-			inp2[1] * lutt6[7]
+			inp2[0] * lutt6[4] +
+			inp2[1] * lutt6[7] +
+			inp1[6] * lutt6[6]
 		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -65,12 +65,15 @@ void FILTER2() {
 	inp1 = (i16 *)(save);
 	outp = outbuff;
 	inp2 = (i16 *)(BufferSpace + inPtr);
-	for (x = 0; x < 8; x++)
-		inputs_matrix[15 - (x + 0)] = inp1[x];
-	for (x = 0; x < 8; x++)
-		inputs_matrix[15 - (x + 8)] = inp2[x];
 
 	for (x = 0; x < cnt; x += 0x10) {
+		for (i = 0; i < 8; i++)
+			inputs_matrix[15 - (i + 0)] = inp1[i];
+		for (i = 0; i < 8; i++)
+			inputs_matrix[15 - (i + 8)] = inp2[i];
+		inp1 = inp2 + 0;
+		inp2 = inp2 + 8;
+
 		packed_multiply_accumulate(&out1[0], &inputs_matrix[0], &lutt6[0], 6);
 		packed_multiply_accumulate(&out1[1], &inputs_matrix[0], &lutt6[0], 7);
 		packed_multiply_accumulate(&out1[2], &inputs_matrix[0], &lutt6[0], 4);
@@ -91,8 +94,6 @@ void FILTER2() {
 		for (i = 0; i < 8; i++)
 			outp[i] = pack_signed(outp[i]);
 #endif
-		inp1 = inp2;
-		inp2 += 8;
 		outp += 8;
 	}
 	//			memcpy (rdram+(t9&0xFFFFFF), dmem+0xFB0, 0x20);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -56,84 +56,84 @@ void FILTER2() {
 
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
-			inputs_matrix[( 9) ^ 1] * lutt6[1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[0] +
-			inputs_matrix[( 7) ^ 1] * lutt6[3] +
-			inputs_matrix[( 6) ^ 1] * lutt6[2] +
-			inputs_matrix[( 5) ^ 1] * lutt6[5] +
-			inputs_matrix[( 4) ^ 1] * lutt6[4] +
-			inputs_matrix[( 3) ^ 1] * lutt6[7] +
-			inputs_matrix[( 2) ^ 1] * lutt6[6]
+			inputs_matrix[( 9) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 2) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[1] =
-			inputs_matrix[( 8) ^ 1] * lutt6[1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[0] +
-			inputs_matrix[( 6) ^ 1] * lutt6[3] +
-			inputs_matrix[( 5) ^ 1] * lutt6[2] +
-			inputs_matrix[( 4) ^ 1] * lutt6[5] +
-			inputs_matrix[( 3) ^ 1] * lutt6[4] +
-			inputs_matrix[( 2) ^ 1] * lutt6[7] +
-			inputs_matrix[( 1) ^ 1] * lutt6[6]
+			inputs_matrix[( 8) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 2) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 1) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[2] =
-			inputs_matrix[(11) ^ 1] * lutt6[1] +
-			inputs_matrix[(10) ^ 1] * lutt6[0] +
-			inputs_matrix[( 9) ^ 1] * lutt6[3] +
-			inputs_matrix[( 8) ^ 1] * lutt6[2] +
-			inputs_matrix[( 7) ^ 1] * lutt6[5] +
-			inputs_matrix[( 6) ^ 1] * lutt6[4] +
-			inputs_matrix[( 5) ^ 1] * lutt6[7] +
-			inputs_matrix[( 4) ^ 1] * lutt6[6]
+			inputs_matrix[(11) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[3] =
-			inputs_matrix[(10) ^ 1] * lutt6[1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[0] +
-			inputs_matrix[( 8) ^ 1] * lutt6[3] +
-			inputs_matrix[( 7) ^ 1] * lutt6[2] +
-			inputs_matrix[( 6) ^ 1] * lutt6[5] +
-			inputs_matrix[( 5) ^ 1] * lutt6[4] +
-			inputs_matrix[( 4) ^ 1] * lutt6[7] +
-			inputs_matrix[( 3) ^ 1] * lutt6[6]
+			inputs_matrix[(10) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[4] =
-			inputs_matrix[(13) ^ 1] * lutt6[1] +
-			inputs_matrix[(12) ^ 1] * lutt6[0] +
-			inputs_matrix[(11) ^ 1] * lutt6[3] +
-			inputs_matrix[(10) ^ 1] * lutt6[2] +
-			inputs_matrix[( 9) ^ 1] * lutt6[5] +
-			inputs_matrix[( 8) ^ 1] * lutt6[4] +
-			inputs_matrix[( 7) ^ 1] * lutt6[7] +
-			inputs_matrix[( 6) ^ 1] * lutt6[6]
+			inputs_matrix[(13) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[5] =
-			inputs_matrix[(12) ^ 1] * lutt6[1] +
-			inputs_matrix[(11) ^ 1] * lutt6[0] +
-			inputs_matrix[(10) ^ 1] * lutt6[3] +
-			inputs_matrix[( 9) ^ 1] * lutt6[2] +
-			inputs_matrix[( 8) ^ 1] * lutt6[5] +
-			inputs_matrix[( 7) ^ 1] * lutt6[4] +
-			inputs_matrix[( 6) ^ 1] * lutt6[7] +
-			inputs_matrix[( 5) ^ 1] * lutt6[6]
+			inputs_matrix[(12) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[6] =
-			inputs_matrix[(15) ^ 1] * lutt6[1] +
-			inputs_matrix[(14) ^ 1] * lutt6[0] +
-			inputs_matrix[(13) ^ 1] * lutt6[3] +
-			inputs_matrix[(12) ^ 1] * lutt6[2] +
-			inputs_matrix[(11) ^ 1] * lutt6[5] +
-			inputs_matrix[(10) ^ 1] * lutt6[4] +
-			inputs_matrix[( 9) ^ 1] * lutt6[7] +
-			inputs_matrix[( 8) ^ 1] * lutt6[6]
+			inputs_matrix[(15) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[(14) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[(13) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[7] =
-			inputs_matrix[(14) ^ 1] * lutt6[1] +
-			inputs_matrix[(13) ^ 1] * lutt6[0] +
-			inputs_matrix[(12) ^ 1] * lutt6[3] +
-			inputs_matrix[(11) ^ 1] * lutt6[2] +
-			inputs_matrix[(10) ^ 1] * lutt6[5] +
-			inputs_matrix[( 9) ^ 1] * lutt6[4] +
-			inputs_matrix[( 8) ^ 1] * lutt6[7] +
-			inputs_matrix[( 7) ^ 1] * lutt6[6]
+			inputs_matrix[(14) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[(13) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[7 ^ 1]
 		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -50,90 +50,90 @@ void FILTER2() {
 	outp = outbuff;
 	inp2 = (i16 *)(BufferSpace + inPtr);
 	for (x = 0; x < 8; x++)
-		inputs_matrix[x + 0] = inp1[x];
+		inputs_matrix[15 - (x + 0)] = inp1[x];
 	for (x = 0; x < 8; x++)
-		inputs_matrix[x + 8] = inp2[x];
+		inputs_matrix[15 - (x + 8)] = inp2[x];
 
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
-			inputs_matrix[( 9) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 2) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 6) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[(13) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[1] =
-			inputs_matrix[( 8) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 2) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 1) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 7) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[(13) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[(14) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[2] =
-			inputs_matrix[(11) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 4) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[3] =
-			inputs_matrix[(10) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 5) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[(11) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[(12) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[4] =
-			inputs_matrix[(13) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 2) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[5] =
-			inputs_matrix[(12) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 3) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[(10) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[6] =
-			inputs_matrix[(15) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[(14) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[(13) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 0) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 1) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 2) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[7 ^ 1]
 		;
 		out1[7] =
-			inputs_matrix[(14) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[(13) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[7 ^ 1]
+			inputs_matrix[( 1) ^ 1] * lutt6[0 ^ 1] +
+			inputs_matrix[( 2) ^ 1] * lutt6[1 ^ 1] +
+			inputs_matrix[( 3) ^ 1] * lutt6[2 ^ 1] +
+			inputs_matrix[( 4) ^ 1] * lutt6[3 ^ 1] +
+			inputs_matrix[( 5) ^ 1] * lutt6[4 ^ 1] +
+			inputs_matrix[( 6) ^ 1] * lutt6[5 ^ 1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[6 ^ 1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[7 ^ 1]
 		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -11,6 +11,22 @@
 
 #include "audiohle.h"
 
+/*
+ * Some combination of RSP LWC2 pack-type operations and vector multiply-
+ * accumulate going on here, doing some fancy matrix math from data memory.
+ */
+static void packed_multiply_accumulate(pi32 acc, pi16 vs, pi16 vt, int offset)
+{
+	i32 result;
+	register int i;
+
+	result = 0;
+	for (i = 0; i < 8; i++)
+		result += (s32)vs[(i + offset) ^ 1] * (s32)vt[i ^ 1];
+	*(acc) = result;
+	return;
+}
+
 void FILTER2() {
 	int x;
 	static int cnt = 0;
@@ -55,86 +71,14 @@ void FILTER2() {
 		inputs_matrix[15 - (x + 8)] = inp2[x];
 
 	for (x = 0; x < cnt; x += 0x10) {
-		out1[0] =
-			inputs_matrix[( 6) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[(13) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[1] =
-			inputs_matrix[( 7) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[(13) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[(14) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[2] =
-			inputs_matrix[( 4) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[3] =
-			inputs_matrix[( 5) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[(11) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[(12) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[4] =
-			inputs_matrix[( 2) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[5] =
-			inputs_matrix[( 3) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 9) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[(10) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[6] =
-			inputs_matrix[( 0) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 1) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 2) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[7 ^ 1]
-		;
-		out1[7] =
-			inputs_matrix[( 1) ^ 1] * lutt6[0 ^ 1] +
-			inputs_matrix[( 2) ^ 1] * lutt6[1 ^ 1] +
-			inputs_matrix[( 3) ^ 1] * lutt6[2 ^ 1] +
-			inputs_matrix[( 4) ^ 1] * lutt6[3 ^ 1] +
-			inputs_matrix[( 5) ^ 1] * lutt6[4 ^ 1] +
-			inputs_matrix[( 6) ^ 1] * lutt6[5 ^ 1] +
-			inputs_matrix[( 7) ^ 1] * lutt6[6 ^ 1] +
-			inputs_matrix[( 8) ^ 1] * lutt6[7 ^ 1]
-		;
+		packed_multiply_accumulate(&out1[0], &inputs_matrix[0], &lutt6[0], 6);
+		packed_multiply_accumulate(&out1[1], &inputs_matrix[0], &lutt6[0], 7);
+		packed_multiply_accumulate(&out1[2], &inputs_matrix[0], &lutt6[0], 4);
+		packed_multiply_accumulate(&out1[3], &inputs_matrix[0], &lutt6[0], 5);
+		packed_multiply_accumulate(&out1[4], &inputs_matrix[0], &lutt6[0], 2);
+		packed_multiply_accumulate(&out1[5], &inputs_matrix[0], &lutt6[0], 3);
+		packed_multiply_accumulate(&out1[6], &inputs_matrix[0], &lutt6[0], 0);
+		packed_multiply_accumulate(&out1[7], &inputs_matrix[0], &lutt6[0], 1);
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);
 		outp[1] = /*CLAMP*/(s16)((out1[1] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -67,14 +67,16 @@ void FILTER2() {
 	outp = outbuff;
 	inp2 = (i16 *)(BufferSpace + inPtr);
 
-	for (x = 0; x < cnt; x += 0x10) {
-		for (i = 0; i < 8; i++)
-			inputs_matrix[15 - (i + 0)] = inp1[i];
-		for (i = 0; i < 8; i++)
-			inputs_matrix[15 - (i + 8)] = inp2[i];
-		inp1 = inp2 + 0;
-		inp2 = inp2 + 8;
+/*
+ * The first iteration has no contiguity between inp1 and inp2.
+ * Every iteration thereafter, they are contiguous:  inp1 = inp2; inp2 += 8;
+ */
+	for (i = 0; i < 8; i++)
+		inputs_matrix[15 - (i + 0)] = inp1[i];
+	for (i = 0; i < 8; i++)
+		inputs_matrix[15 - (i + 8)] = inp2[i];
 
+	for (x = 0; x < cnt; x += 0x10) {
 		packed_multiply_accumulate(&out1[0], &inputs_matrix[0], &lutt6[0], 6);
 		packed_multiply_accumulate(&out1[1], &inputs_matrix[0], &lutt6[0], 7);
 		packed_multiply_accumulate(&out1[2], &inputs_matrix[0], &lutt6[0], 4);
@@ -96,6 +98,12 @@ void FILTER2() {
 			outp[i] = pack_signed(outp[i]);
 #endif
 		outp += 8;
+
+		inp1 = inp2 + 0;
+		inp2 = inp2 + 8;
+
+		for (i = 0; i < 16; i++)
+			inputs_matrix[15 - i] = inp1[i];
 	}
 	//			memcpy (rdram+(t9&0xFFFFFF), dmem+0xFB0, 0x20);
 	memcpy(save, inp2 - 8, 0x10);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -40,93 +40,100 @@ void FILTER2() {
 		a = (lutt5[x] + lutt6[x]) >> 1;
 		lutt5[x] = lutt6[x] = (short)a;
 	}
+	i16 inputs_matrix[16];
 	pi16 inp1, inp2;
 	s32 out1[8];
 	s16 outbuff[0x3c0], *outp;
 	u32 inPtr = (u32)(k0 & 0xffff);
+
 	inp1 = (i16 *)(save);
 	outp = outbuff;
 	inp2 = (i16 *)(BufferSpace + inPtr);
+	for (x = 0; x < 8; x++)
+		inputs_matrix[x + 0] = inp1[x];
+	for (x = 0; x < 8; x++)
+		inputs_matrix[x + 8] = inp2[x];
+
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
-			inp2[0] * lutt6[1] +
-			inp2[1] * lutt6[0] +
-			inp1[6] * lutt6[3] +
-			inp1[7] * lutt6[2] +
-			inp1[4] * lutt6[5] +
-			inp1[5] * lutt6[4] +
-			inp1[2] * lutt6[7] +
-			inp1[3] * lutt6[6]
+			inputs_matrix[ 8] * lutt6[1] +
+			inputs_matrix[ 9] * lutt6[0] +
+			inputs_matrix[ 6] * lutt6[3] +
+			inputs_matrix[ 7] * lutt6[2] +
+			inputs_matrix[ 4] * lutt6[5] +
+			inputs_matrix[ 5] * lutt6[4] +
+			inputs_matrix[ 2] * lutt6[7] +
+			inputs_matrix[ 3] * lutt6[6]
 		;
 		out1[1] =
-			inp2[1] * lutt6[1] +
-			inp1[6] * lutt6[0] +
-			inp1[7] * lutt6[3] +
-			inp1[4] * lutt6[2] +
-			inp1[5] * lutt6[5] +
-			inp1[2] * lutt6[4] +
-			inp1[3] * lutt6[7] +
-			inp1[0] * lutt6[6]
+			inputs_matrix[ 9] * lutt6[1] +
+			inputs_matrix[ 6] * lutt6[0] +
+			inputs_matrix[ 7] * lutt6[3] +
+			inputs_matrix[ 4] * lutt6[2] +
+			inputs_matrix[ 5] * lutt6[5] +
+			inputs_matrix[ 2] * lutt6[4] +
+			inputs_matrix[ 3] * lutt6[7] +
+			inputs_matrix[ 0] * lutt6[6]
 		;
 		out1[2] =
-			inp2[2] * lutt6[1] +
-			inp2[3] * lutt6[0] +
-			inp2[0] * lutt6[3] +
-			inp2[1] * lutt6[2] +
-			inp1[6] * lutt6[5] +
-			inp1[7] * lutt6[4] +
-			inp1[4] * lutt6[7] +
-			inp1[5] * lutt6[6]
+			inputs_matrix[10] * lutt6[1] +
+			inputs_matrix[11] * lutt6[0] +
+			inputs_matrix[ 8] * lutt6[3] +
+			inputs_matrix[ 9] * lutt6[2] +
+			inputs_matrix[ 6] * lutt6[5] +
+			inputs_matrix[ 7] * lutt6[4] +
+			inputs_matrix[ 4] * lutt6[7] +
+			inputs_matrix[ 5] * lutt6[6]
 		;
 		out1[3] =
-			inp2[3] * lutt6[1] +
-			inp2[0] * lutt6[0] +
-			inp2[1] * lutt6[3] +
-			inp1[6] * lutt6[2] +
-			inp1[7] * lutt6[5] +
-			inp1[4] * lutt6[4] +
-			inp1[5] * lutt6[7] +
-			inp1[2] * lutt6[6]
+			inputs_matrix[11] * lutt6[1] +
+			inputs_matrix[ 8] * lutt6[0] +
+			inputs_matrix[ 9] * lutt6[3] +
+			inputs_matrix[ 6] * lutt6[2] +
+			inputs_matrix[ 7] * lutt6[5] +
+			inputs_matrix[ 4] * lutt6[4] +
+			inputs_matrix[ 5] * lutt6[7] +
+			inputs_matrix[ 2] * lutt6[6]
 		;
 		out1[4] =
-			inp2[4] * lutt6[1] +
-			inp2[5] * lutt6[0] +
-			inp2[2] * lutt6[3] +
-			inp2[3] * lutt6[2] +
-			inp2[0] * lutt6[5] +
-			inp2[1] * lutt6[4] +
-			inp1[6] * lutt6[7] +
-			inp1[7] * lutt6[6]
+			inputs_matrix[12] * lutt6[1] +
+			inputs_matrix[13] * lutt6[0] +
+			inputs_matrix[10] * lutt6[3] +
+			inputs_matrix[11] * lutt6[2] +
+			inputs_matrix[ 8] * lutt6[5] +
+			inputs_matrix[ 9] * lutt6[4] +
+			inputs_matrix[ 6] * lutt6[7] +
+			inputs_matrix[ 7] * lutt6[6]
 		;
 		out1[5] =
-			inp2[5] * lutt6[1] +
-			inp2[2] * lutt6[0] +
-			inp2[3] * lutt6[3] +
-			inp2[0] * lutt6[2] +
-			inp2[1] * lutt6[5] +
-			inp1[6] * lutt6[4] +
-			inp1[7] * lutt6[7] +
-			inp1[4] * lutt6[6]
+			inputs_matrix[13] * lutt6[1] +
+			inputs_matrix[10] * lutt6[0] +
+			inputs_matrix[11] * lutt6[3] +
+			inputs_matrix[ 8] * lutt6[2] +
+			inputs_matrix[ 9] * lutt6[5] +
+			inputs_matrix[ 6] * lutt6[4] +
+			inputs_matrix[ 7] * lutt6[7] +
+			inputs_matrix[ 4] * lutt6[6]
 		;
 		out1[6] =
-			inp2[6] * lutt6[1] +
-			inp2[7] * lutt6[0] +
-			inp2[4] * lutt6[3] +
-			inp2[5] * lutt6[2] +
-			inp2[2] * lutt6[5] +
-			inp2[3] * lutt6[4] +
-			inp2[0] * lutt6[7] +
-			inp2[1] * lutt6[6]
+			inputs_matrix[14] * lutt6[1] +
+			inputs_matrix[15] * lutt6[0] +
+			inputs_matrix[12] * lutt6[3] +
+			inputs_matrix[13] * lutt6[2] +
+			inputs_matrix[10] * lutt6[5] +
+			inputs_matrix[11] * lutt6[4] +
+			inputs_matrix[ 8] * lutt6[7] +
+			inputs_matrix[ 9] * lutt6[6]
 		;
 		out1[7] =
-			inp2[7] * lutt6[1] +
-			inp2[4] * lutt6[0] +
-			inp2[5] * lutt6[3] +
-			inp2[2] * lutt6[2] +
-			inp2[3] * lutt6[5] +
-			inp2[0] * lutt6[4] +
-			inp2[1] * lutt6[7] +
-			inp1[6] * lutt6[6]
+			inputs_matrix[15] * lutt6[1] +
+			inputs_matrix[12] * lutt6[0] +
+			inputs_matrix[13] * lutt6[3] +
+			inputs_matrix[10] * lutt6[2] +
+			inputs_matrix[11] * lutt6[5] +
+			inputs_matrix[ 8] * lutt6[4] +
+			inputs_matrix[ 9] * lutt6[7] +
+			inputs_matrix[ 6] * lutt6[6]
 		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -57,7 +57,8 @@ void FILTER2() {
 		lutt5[x] = lutt6[x] = (short)a;
 	}
 	i16 inputs_matrix[16];
-	pi16 inp1, inp2;
+	i16* inp1;
+	i16* inp2;
 	s32 out1[8];
 	s16 outbuff[0x3c0], *outp;
 	u32 inPtr = (u32)(k0 & 0xffff);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -28,7 +28,7 @@ static void packed_multiply_accumulate(pi32 acc, pi16 vs, pi16 vt, int offset)
 }
 
 void FILTER2() {
-	int x;
+	int x, i;
 	static int cnt = 0;
 	static s16 *lutt6;
 	static s16 *lutt5;
@@ -80,14 +80,17 @@ void FILTER2() {
 		packed_multiply_accumulate(&out1[6], &inputs_matrix[0], &lutt6[0], 0);
 		packed_multiply_accumulate(&out1[7], &inputs_matrix[0], &lutt6[0], 1);
 
-		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);
-		outp[1] = /*CLAMP*/(s16)((out1[1] + 0x4000) >> 0xF);
-		outp[2] = /*CLAMP*/(s16)((out1[2] + 0x4000) >> 0xF);
-		outp[3] = /*CLAMP*/(s16)((out1[3] + 0x4000) >> 0xF);
-		outp[4] = /*CLAMP*/(s16)((out1[4] + 0x4000) >> 0xF);
-		outp[5] = /*CLAMP*/(s16)((out1[5] + 0x4000) >> 0xF);
-		outp[6] = /*CLAMP*/(s16)((out1[6] + 0x4000) >> 0xF);
-		outp[7] = /*CLAMP*/(s16)((out1[7] + 0x4000) >> 0xF);
+		for (i = 0; i < 8; i++)
+			outp[i] = (out1[i] + 0x4000) >> 15; /* fractional round and shift */
+#if 0
+/*
+ * Clamp the result to fit within the legal range of 16-bit short elements.
+ * VMULF, I know, never needs this in games, because the only way for VMULF
+ * to produce an out-of-range value is if audio ucode does -32768 * -32768.
+ */
+		for (i = 0; i < 8; i++)
+			outp[i] = pack_signed(outp[i]);
+#endif
 		inp1 = inp2;
 		inp2 += 8;
 		outp += 8;

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -40,13 +40,13 @@ void FILTER2() {
 		a = (lutt5[x] + lutt6[x]) >> 1;
 		lutt5[x] = lutt6[x] = (short)a;
 	}
-	short *inp1, *inp2;
+	pi16 inp1, inp2;
 	s32 out1[8];
 	s16 outbuff[0x3c0], *outp;
 	u32 inPtr = (u32)(k0 & 0xffff);
-	inp1 = (short *)(save);
+	inp1 = (i16 *)(save);
 	outp = outbuff;
-	inp2 = (short *)(BufferSpace + inPtr);
+	inp2 = (i16 *)(BufferSpace + inPtr);
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
 			inp2[0] * lutt6[1] +

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -95,6 +95,8 @@ void FILTER2() {
  * to produce an out-of-range value is if audio ucode does -32768 * -32768.
  */
 		for (i = 0; i < 8; i++)
+			assert(outp[i] >= -32768 && outp[i] <= +32767);
+		for (i = 0; i < 8; i++)
 			outp[i] = pack_signed(outp[i]);
 #endif
 		outp += 8;

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -48,77 +48,86 @@ void FILTER2() {
 	outp = outbuff;
 	inp2 = (short *)(BufferSpace + inPtr);
 	for (x = 0; x < cnt; x += 0x10) {
-		out1[0]  = inp2[1] * lutt6[0];
-		out1[0] += inp2[0] * lutt6[1];
-		out1[0] += inp1[7] * lutt6[2];
-		out1[0] += inp1[6] * lutt6[3];
-		out1[0] += inp1[5] * lutt6[4];
-		out1[0] += inp1[4] * lutt6[5];
-		out1[0] += inp1[3] * lutt6[6];
-		out1[0] += inp1[2] * lutt6[7];
-
-		out1[1]  = inp1[6] * lutt6[0];
-		out1[1] += inp2[1] * lutt6[1]; // 1
-		out1[1] += inp1[4] * lutt6[2];
-		out1[1] += inp1[7] * lutt6[3];
-		out1[1] += inp1[2] * lutt6[4];
-		out1[1] += inp1[5] * lutt6[5];
-		out1[1] += inp1[0] * lutt6[6];
-		out1[1] += inp1[3] * lutt6[7];
-
-		out1[2]  = inp2[3] * lutt6[0];
-		out1[2] += inp2[2] * lutt6[1];
-		out1[2] += inp2[1] * lutt6[2];
-		out1[2] += inp2[0] * lutt6[3];
-		out1[2] += inp1[7] * lutt6[4];
-		out1[2] += inp1[6] * lutt6[5];
-		out1[2] += inp1[5] * lutt6[6];
-		out1[2] += inp1[4] * lutt6[7];
-
-		out1[3]  = inp2[0] * lutt6[0];
-		out1[3] += inp2[3] * lutt6[1];
-		out1[3] += inp1[6] * lutt6[2];
-		out1[3] += inp2[1] * lutt6[3];
-		out1[3] += inp1[4] * lutt6[4];
-		out1[3] += inp1[7] * lutt6[5];
-		out1[3] += inp1[2] * lutt6[6];
-		out1[3] += inp1[5] * lutt6[7];
-
-		out1[4]  = inp2[5] * lutt6[0];
-		out1[4] += inp2[4] * lutt6[1];
-		out1[4] += inp2[3] * lutt6[2];
-		out1[4] += inp2[2] * lutt6[3];
-		out1[4] += inp2[1] * lutt6[4];
-		out1[4] += inp2[0] * lutt6[5];
-		out1[4] += inp1[7] * lutt6[6];
-		out1[4] += inp1[6] * lutt6[7];
-
-		out1[5]  = inp2[2] * lutt6[0];
-		out1[5] += inp2[5] * lutt6[1];
-		out1[5] += inp2[0] * lutt6[2];
-		out1[5] += inp2[3] * lutt6[3];
-		out1[5] += inp1[6] * lutt6[4];
-		out1[5] += inp2[1] * lutt6[5];
-		out1[5] += inp1[4] * lutt6[6];
-		out1[5] += inp1[7] * lutt6[7];
-
-		out1[6]  = inp2[7] * lutt6[0];
-		out1[6] += inp2[6] * lutt6[1];
-		out1[6] += inp2[5] * lutt6[2];
-		out1[6] += inp2[4] * lutt6[3];
-		out1[6] += inp2[3] * lutt6[4];
-		out1[6] += inp2[2] * lutt6[5];
-		out1[6] += inp2[1] * lutt6[6];
-		out1[6] += inp2[0] * lutt6[7];
-
-		out1[7]  = inp2[4] * lutt6[0];
-		out1[7] += inp2[7] * lutt6[1];
-		out1[7] += inp2[2] * lutt6[2];
-		out1[7] += inp2[5] * lutt6[3];
-		out1[7] += inp2[0] * lutt6[4];
-		out1[7] += inp2[3] * lutt6[5];
-		out1[7] += inp1[6] * lutt6[6];
-		out1[7] += inp2[1] * lutt6[7];
+		out1[0] =
+			inp2[1] * lutt6[0] +
+			inp2[0] * lutt6[1] +
+			inp1[7] * lutt6[2] +
+			inp1[6] * lutt6[3] +
+			inp1[5] * lutt6[4] +
+			inp1[4] * lutt6[5] +
+			inp1[3] * lutt6[6] +
+			inp1[2] * lutt6[7]
+		;
+		out1[1] =
+			inp1[6] * lutt6[0] +
+			inp2[1] * lutt6[1] +
+			inp1[4] * lutt6[2] +
+			inp1[7] * lutt6[3] +
+			inp1[2] * lutt6[4] +
+			inp1[5] * lutt6[5] +
+			inp1[0] * lutt6[6] +
+			inp1[3] * lutt6[7]
+		;
+		out1[2] =
+			inp2[3] * lutt6[0] +
+			inp2[2] * lutt6[1] +
+			inp2[1] * lutt6[2] +
+			inp2[0] * lutt6[3] +
+			inp1[7] * lutt6[4] +
+			inp1[6] * lutt6[5] +
+			inp1[5] * lutt6[6] +
+			inp1[4] * lutt6[7]
+		;
+		out1[3] =
+			inp2[0] * lutt6[0] +
+			inp2[3] * lutt6[1] +
+			inp1[6] * lutt6[2] +
+			inp2[1] * lutt6[3] +
+			inp1[4] * lutt6[4] +
+			inp1[7] * lutt6[5] +
+			inp1[2] * lutt6[6] +
+			inp1[5] * lutt6[7]
+		;
+		out1[4] =
+			inp2[5] * lutt6[0] +
+			inp2[4] * lutt6[1] +
+			inp2[3] * lutt6[2] +
+			inp2[2] * lutt6[3] +
+			inp2[1] * lutt6[4] +
+			inp2[0] * lutt6[5] +
+			inp1[7] * lutt6[6] +
+			inp1[6] * lutt6[7]
+		;
+		out1[5] =
+			inp2[2] * lutt6[0] +
+			inp2[5] * lutt6[1] +
+			inp2[0] * lutt6[2] +
+			inp2[3] * lutt6[3] +
+			inp1[6] * lutt6[4] +
+			inp2[1] * lutt6[5] +
+			inp1[4] * lutt6[6] +
+			inp1[7] * lutt6[7]
+		;
+		out1[6] =
+			inp2[7] * lutt6[0] +
+			inp2[6] * lutt6[1] +
+			inp2[5] * lutt6[2] +
+			inp2[4] * lutt6[3] +
+			inp2[3] * lutt6[4] +
+			inp2[2] * lutt6[5] +
+			inp2[1] * lutt6[6] +
+			inp2[0] * lutt6[7]
+		;
+		out1[7] =
+			inp2[4] * lutt6[0] +
+			inp2[7] * lutt6[1] +
+			inp2[2] * lutt6[2] +
+			inp2[5] * lutt6[3] +
+			inp2[0] * lutt6[4] +
+			inp2[3] * lutt6[5] +
+			inp1[6] * lutt6[6] +
+			inp2[1] * lutt6[7]
+		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);
 		outp[1] = /*CLAMP*/(s16)((out1[1] + 0x4000) >> 0xF);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -56,84 +56,84 @@ void FILTER2() {
 
 	for (x = 0; x < cnt; x += 0x10) {
 		out1[0] =
-			inputs_matrix[ 8] * lutt6[1] +
-			inputs_matrix[ 9] * lutt6[0] +
-			inputs_matrix[ 6] * lutt6[3] +
-			inputs_matrix[ 7] * lutt6[2] +
-			inputs_matrix[ 4] * lutt6[5] +
-			inputs_matrix[ 5] * lutt6[4] +
-			inputs_matrix[ 2] * lutt6[7] +
-			inputs_matrix[ 3] * lutt6[6]
+			inputs_matrix[( 9) ^ 1] * lutt6[1] +
+			inputs_matrix[( 8) ^ 1] * lutt6[0] +
+			inputs_matrix[( 7) ^ 1] * lutt6[3] +
+			inputs_matrix[( 6) ^ 1] * lutt6[2] +
+			inputs_matrix[( 5) ^ 1] * lutt6[5] +
+			inputs_matrix[( 4) ^ 1] * lutt6[4] +
+			inputs_matrix[( 3) ^ 1] * lutt6[7] +
+			inputs_matrix[( 2) ^ 1] * lutt6[6]
 		;
 		out1[1] =
-			inputs_matrix[ 9] * lutt6[1] +
-			inputs_matrix[ 6] * lutt6[0] +
-			inputs_matrix[ 7] * lutt6[3] +
-			inputs_matrix[ 4] * lutt6[2] +
-			inputs_matrix[ 5] * lutt6[5] +
-			inputs_matrix[ 2] * lutt6[4] +
-			inputs_matrix[ 3] * lutt6[7] +
-			inputs_matrix[ 0] * lutt6[6]
+			inputs_matrix[( 8) ^ 1] * lutt6[1] +
+			inputs_matrix[( 7) ^ 1] * lutt6[0] +
+			inputs_matrix[( 6) ^ 1] * lutt6[3] +
+			inputs_matrix[( 5) ^ 1] * lutt6[2] +
+			inputs_matrix[( 4) ^ 1] * lutt6[5] +
+			inputs_matrix[( 3) ^ 1] * lutt6[4] +
+			inputs_matrix[( 2) ^ 1] * lutt6[7] +
+			inputs_matrix[( 1) ^ 1] * lutt6[6]
 		;
 		out1[2] =
-			inputs_matrix[10] * lutt6[1] +
-			inputs_matrix[11] * lutt6[0] +
-			inputs_matrix[ 8] * lutt6[3] +
-			inputs_matrix[ 9] * lutt6[2] +
-			inputs_matrix[ 6] * lutt6[5] +
-			inputs_matrix[ 7] * lutt6[4] +
-			inputs_matrix[ 4] * lutt6[7] +
-			inputs_matrix[ 5] * lutt6[6]
+			inputs_matrix[(11) ^ 1] * lutt6[1] +
+			inputs_matrix[(10) ^ 1] * lutt6[0] +
+			inputs_matrix[( 9) ^ 1] * lutt6[3] +
+			inputs_matrix[( 8) ^ 1] * lutt6[2] +
+			inputs_matrix[( 7) ^ 1] * lutt6[5] +
+			inputs_matrix[( 6) ^ 1] * lutt6[4] +
+			inputs_matrix[( 5) ^ 1] * lutt6[7] +
+			inputs_matrix[( 4) ^ 1] * lutt6[6]
 		;
 		out1[3] =
-			inputs_matrix[11] * lutt6[1] +
-			inputs_matrix[ 8] * lutt6[0] +
-			inputs_matrix[ 9] * lutt6[3] +
-			inputs_matrix[ 6] * lutt6[2] +
-			inputs_matrix[ 7] * lutt6[5] +
-			inputs_matrix[ 4] * lutt6[4] +
-			inputs_matrix[ 5] * lutt6[7] +
-			inputs_matrix[ 2] * lutt6[6]
+			inputs_matrix[(10) ^ 1] * lutt6[1] +
+			inputs_matrix[( 9) ^ 1] * lutt6[0] +
+			inputs_matrix[( 8) ^ 1] * lutt6[3] +
+			inputs_matrix[( 7) ^ 1] * lutt6[2] +
+			inputs_matrix[( 6) ^ 1] * lutt6[5] +
+			inputs_matrix[( 5) ^ 1] * lutt6[4] +
+			inputs_matrix[( 4) ^ 1] * lutt6[7] +
+			inputs_matrix[( 3) ^ 1] * lutt6[6]
 		;
 		out1[4] =
-			inputs_matrix[12] * lutt6[1] +
-			inputs_matrix[13] * lutt6[0] +
-			inputs_matrix[10] * lutt6[3] +
-			inputs_matrix[11] * lutt6[2] +
-			inputs_matrix[ 8] * lutt6[5] +
-			inputs_matrix[ 9] * lutt6[4] +
-			inputs_matrix[ 6] * lutt6[7] +
-			inputs_matrix[ 7] * lutt6[6]
+			inputs_matrix[(13) ^ 1] * lutt6[1] +
+			inputs_matrix[(12) ^ 1] * lutt6[0] +
+			inputs_matrix[(11) ^ 1] * lutt6[3] +
+			inputs_matrix[(10) ^ 1] * lutt6[2] +
+			inputs_matrix[( 9) ^ 1] * lutt6[5] +
+			inputs_matrix[( 8) ^ 1] * lutt6[4] +
+			inputs_matrix[( 7) ^ 1] * lutt6[7] +
+			inputs_matrix[( 6) ^ 1] * lutt6[6]
 		;
 		out1[5] =
-			inputs_matrix[13] * lutt6[1] +
-			inputs_matrix[10] * lutt6[0] +
-			inputs_matrix[11] * lutt6[3] +
-			inputs_matrix[ 8] * lutt6[2] +
-			inputs_matrix[ 9] * lutt6[5] +
-			inputs_matrix[ 6] * lutt6[4] +
-			inputs_matrix[ 7] * lutt6[7] +
-			inputs_matrix[ 4] * lutt6[6]
+			inputs_matrix[(12) ^ 1] * lutt6[1] +
+			inputs_matrix[(11) ^ 1] * lutt6[0] +
+			inputs_matrix[(10) ^ 1] * lutt6[3] +
+			inputs_matrix[( 9) ^ 1] * lutt6[2] +
+			inputs_matrix[( 8) ^ 1] * lutt6[5] +
+			inputs_matrix[( 7) ^ 1] * lutt6[4] +
+			inputs_matrix[( 6) ^ 1] * lutt6[7] +
+			inputs_matrix[( 5) ^ 1] * lutt6[6]
 		;
 		out1[6] =
-			inputs_matrix[14] * lutt6[1] +
-			inputs_matrix[15] * lutt6[0] +
-			inputs_matrix[12] * lutt6[3] +
-			inputs_matrix[13] * lutt6[2] +
-			inputs_matrix[10] * lutt6[5] +
-			inputs_matrix[11] * lutt6[4] +
-			inputs_matrix[ 8] * lutt6[7] +
-			inputs_matrix[ 9] * lutt6[6]
+			inputs_matrix[(15) ^ 1] * lutt6[1] +
+			inputs_matrix[(14) ^ 1] * lutt6[0] +
+			inputs_matrix[(13) ^ 1] * lutt6[3] +
+			inputs_matrix[(12) ^ 1] * lutt6[2] +
+			inputs_matrix[(11) ^ 1] * lutt6[5] +
+			inputs_matrix[(10) ^ 1] * lutt6[4] +
+			inputs_matrix[( 9) ^ 1] * lutt6[7] +
+			inputs_matrix[( 8) ^ 1] * lutt6[6]
 		;
 		out1[7] =
-			inputs_matrix[15] * lutt6[1] +
-			inputs_matrix[12] * lutt6[0] +
-			inputs_matrix[13] * lutt6[3] +
-			inputs_matrix[10] * lutt6[2] +
-			inputs_matrix[11] * lutt6[5] +
-			inputs_matrix[ 8] * lutt6[4] +
-			inputs_matrix[ 9] * lutt6[7] +
-			inputs_matrix[ 6] * lutt6[6]
+			inputs_matrix[(14) ^ 1] * lutt6[1] +
+			inputs_matrix[(13) ^ 1] * lutt6[0] +
+			inputs_matrix[(12) ^ 1] * lutt6[3] +
+			inputs_matrix[(11) ^ 1] * lutt6[2] +
+			inputs_matrix[(10) ^ 1] * lutt6[5] +
+			inputs_matrix[( 9) ^ 1] * lutt6[4] +
+			inputs_matrix[( 8) ^ 1] * lutt6[7] +
+			inputs_matrix[( 7) ^ 1] * lutt6[6]
 		;
 
 		outp[0] = /*CLAMP*/(s16)((out1[0] + 0x4000) >> 0xF);


### PR DESCRIPTION
Well, here's one that I spent a few more hours on.  Now that the rest of the source has been addressed enough to my liking, I decided to start cleaning up some RSP stuff.  I was most interested in `ABI_Filters.cpp` because I thought it made use of the vector shuffle operands, but it turned out to be 16-bit mixed-/bi-endianness within 32-bit word vector tricks in LWC2 pack operations.  (Man those suck.)  In the end I was able to make a function out of most of that.

I'm not sure yet which games use ABI2 ucode, though, but I'll try to figure that out in the meantime to verify the consequences of my changes.  Ever since the very first commit, I already started to think a little regression testing wouldn't hurt.  I'll address any bugs in these commits if they exist.