### PR TITLE
Have frequency-rounding performed on leveled intervals, through a function.

### DIFF
--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -459,26 +459,28 @@ void DirectSoundDriver::DeInitialize() {
 
 // Buffer Functions for the Audio Code
 void DirectSoundDriver::SetFrequency(DWORD Frequency2) {
+	long freq;
 	DWORD Frequency = Frequency2;
 	BOOL bAudioPlaying = audioIsPlaying;
+
 	printf("SetFrequency()\n");
 	// MusyX - (Frequency / 80) * 4
 	// 
 	if (bAudioPlaying == TRUE) {
 		StopAudio();
 	}
-	/*
-	if (Frequency < 45000 && Frequency > 43000) {
-	Frequency = 44100;
-	}
-	else if (Frequency < 33000 && Frequency > 31000)	{
-	Frequency = 32000;
-	}
-	else if (Frequency < 25000 && Frequency > 20000)	{
-	Frequency = 22050;
-	} else if (Frequency < 15000 && Frequency > 10000) {
-	Frequency = 11025;
-	}*/
+
+	assert(Frequency <= 65535);
+	freq = (long)Frequency;
+
+	freq = filter_range(freq, 44100, 1000);
+	freq = filter_range(freq, 32000, 1000);
+	freq = filter_range(freq, 22050, 1000);
+	freq = filter_range(freq, 11025, 1000);
+
+	Frequency = (DWORD)freq;
+	assert(Frequency <= 44100);
+
 	sLOCK_SIZE = (Frequency / 80) * 4;// 0x600;// (22050 / 30) * 4;// 0x4000;// (Frequency / 60) * 4;
 	SampleRate = Frequency;
 	SegmentSize = 0; // Trash it... we need to redo the Frequency anyway...

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -16,6 +16,11 @@
 #define SND_IS_NOT_EMPTY 0x4000000
 #define SND_IS_FULL		 0x8000000
 
+/*
+ * Filters an integer for proximity within the range (base +/- leeway).
+ * Created mostly just to solve the deviant N64 frequencies problem.
+ */
+extern long filter_range(long x, long base, int leeway);
 
 class SoundDriver
 {

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -188,7 +188,7 @@ void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
 	Frequency = (DWORD)freq;
 	assert(Frequency <= 44100);
 
-	cacheSize = (Frequency / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
+	cacheSize = (freq / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
 	if (Setup() < 0) /* failed to apply a sound device */
 		return;
 	g_source->SetSourceSampleRate(Frequency);

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -173,21 +173,22 @@ void XAudio2SoundDriver::Teardown()
 
 void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
 {
-//	Frequency = (Frequency+25) - ((Frequency+25) % 50);
-	if (Frequency < 45000 && Frequency > 43000) {
-		Frequency = 44100;
-	}
-	else if (Frequency < 33000 && Frequency > 31000)	{
-		Frequency = 32000;
-	}
-	else if (Frequency < 25000 && Frequency > 20000)	{
-		Frequency = 22050;
-	}
-	else if (Frequency < 15000 && Frequency > 10000) {
-		Frequency = 11025;
-	}
-	cacheSize = (Frequency / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
+	long freq;
 
+//	Frequency = (Frequency+25) - ((Frequency+25) % 50);
+
+	assert(Frequency <= 65535);
+	freq = (long)Frequency;
+
+	freq = filter_range(freq, 44100, 1000);
+	freq = filter_range(freq, 32000, 1000);
+	freq = filter_range(freq, 22050, 1000);
+	freq = filter_range(freq, 11025, 1000);
+
+	Frequency = (DWORD)freq;
+	assert(Frequency <= 44100);
+
+	cacheSize = (Frequency / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
 	if (Setup() < 0) /* failed to apply a sound device */
 		return;
 	g_source->SetSourceSampleRate(Frequency);

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -465,3 +465,15 @@ int safe_strcpy(char* dst, size_t limit, const char* src)
     return (failure);
 #endif
 }
+
+long filter_range(long x, long base, int leeway)
+{
+    const long minimum = base - leeway; /* does not prevent signed underflow */
+    const long maximum = base + leeway; /* does not prevent signed overflow */
+
+    if (x < minimum)
+        return (x); /* filter_range(44095, 44100, 4) should return 44095. */
+    if (x > maximum)
+        return (x); /* filter_range(44105, 44100, 4) should return 44105. */
+    return (base);
+}


### PR DESCRIPTION
Not too sure about this one for a couple reasons, but I wanted to see how appropriate it could be to just have a function to address the code complication issue mentioned here?  https://github.com/Frank-74/AziAudio/commit/300d8523c1b51c2b38f5efde762d2f96e75b63bf#commitcomment-11086246

There may be a static, branch-free approach at this too, but atm it's just a function for portability.

Aside from the risk of maintenance with explicit type-cast conversions, my uncertainty with these commits lies in this field here from the comments that I replaced:
```c
} else if (Frequency < 15000 && Frequency > 10000) {
	Frequency = 11025;
```
Here, `Frequency` could be 14999 (almost 4000 Hz more than the original 11025-Hz target approximation) and get saturated to 11025 as a result of this block, but if it was 7025 (4000 Hz **less** than the original) there is no way it is going to be brought closer to the valid 11025 value.  So that is the sort of effect that my function replaces...but, I figured that my method could hopefully be more accurate due to the balanced approach with just a single range deviation rather than an arbitrarily specified min/max like 10000/15000?