### PR TITLE
Only need to change 1 line instead of 2 to update version numbers.

### DIFF
--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -57,10 +57,14 @@ extern rSettings RegSettings;
 unsigned long GenerateCRC (unsigned char *data, int size);
 
 #ifdef USE_XAUDIO2
-#define PLUGIN_VERSION "Azimer's XA2 Audio v0.70 WIP 5"
+#define PLUGIN_NAME     "Azimer's XA2 Audio"
 #else
-#define PLUGIN_VERSION "Azimer's DS8 Audio v0.70 WIP 5"
+#define PLUGIN_NAME     "Azimer's DS8 Audio"
 #endif
+#define PLUGIN_VERSION \
+PLUGIN_NAME \
+" v0.70 WIP 5"
+
 #ifdef ENABLEPROFILING
 
 	extern u64 ProfileStartTimes[30];


### PR DESCRIPTION
Maybe a bit messy with the final macro layout, but, eh, could potentially have some improvement if more than 2 audio APIs were supported and version number got updated frequently, or maybe people might prefer sprintf.