### PR TITLE
folded almost the entirety of the array multiplies/adds in ABI_Filters

### DIFF
--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -17,21 +17,12 @@
  */
 static void packed_multiply_accumulate(pi32 acc, pi16 vs, pi16 vt, int offset)
 {
-	i16 source[16], target[8];
 	i32 result;
 	register int i;
 
-	for (i = 0; i < 16; i++)
-		source[i] = vs[i];
-	for (i = 0; i < 8; i++)
-		target[i] = vt[i];
-	swap_elements(&source[0]);
-	swap_elements(&source[8]);
-	swap_elements(&target[0]);
-
 	result = 0;
 	for (i = 0; i < 8; i++)
-		result += (s32)source[i + offset] * (s32)target[i];
+		result += (s32)vs[i + offset] * (s32)vt[i];
 	*(acc) = result;
 	return;
 }
@@ -82,8 +73,10 @@ void FILTER2() {
  */
 	for (i = 0; i < 8; i++)
 		inputs_matrix[15 - (i + 0)] = inp1[i];
+	swap_elements(&inputs_matrix[8]);
 	for (i = 0; i < 8; i++)
 		inputs_matrix[15 - (i + 8)] = inp2[i];
+	swap_elements(&inputs_matrix[0]);
 
 	for (x = 0; x < cnt; x += 0x10) {
 		packed_multiply_accumulate(&out1[0], &inputs_matrix[0], &lutt6[0], 6);
@@ -115,6 +108,8 @@ void FILTER2() {
 
 		for (i = 0; i < 16; i++)
 			inputs_matrix[15 - i] = inp1[i];
+		swap_elements(&inputs_matrix[0]);
+		swap_elements(&inputs_matrix[8]);
 	}
 	//			memcpy (rdram+(t9&0xFFFFFF), dmem+0xFB0, 0x20);
 	memcpy(save, inp2 - 8, 0x10);

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -17,10 +17,10 @@
  */
 static void packed_multiply_accumulate(i32 * acc, i16 * vs, i16 * vt)
 {
+	i32 pre_buffer[8];
 	i32 result;
 #ifdef SSE2_SUPPORT
 	__m128i xmm_source, xmm_target;
-	i32 pre_buffer[4];
 
 	xmm_source = _mm_loadu_si128((__m128i *)vs);
 	xmm_target = _mm_loadu_si128((__m128i *)vt);
@@ -30,9 +30,11 @@ static void packed_multiply_accumulate(i32 * acc, i16 * vs, i16 * vt)
 #else
 	register int i;
 
+	for (i = 0; i < 8; i++)
+		pre_buffer[i] = (s32)vs[i] * (s32)vt[i];
 	result = 0;
 	for (i = 0; i < 8; i++)
-		result += (s32)vs[i] * (s32)vt[i];
+		result += pre_buffer[i];
 #endif
 	*(acc) = result;
 	return;

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -17,12 +17,21 @@
  */
 static void packed_multiply_accumulate(pi32 acc, pi16 vs, pi16 vt, int offset)
 {
+	i16 source[16], target[8];
 	i32 result;
 	register int i;
 
+	for (i = 0; i < 16; i++)
+		source[i] = vs[i];
+	for (i = 0; i < 8; i++)
+		target[i] = vt[i];
+	swap_elements(&source[0]);
+	swap_elements(&source[8]);
+	swap_elements(&target[0]);
+
 	result = 0;
 	for (i = 0; i < 8; i++)
-		result += (s32)vs[MES(i + offset)] * (s32)vt[MES(i + 0)];
+		result += (s32)source[i + offset] * (s32)target[i];
 	*(acc) = result;
 	return;
 }

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -15,14 +15,14 @@
  * Some combination of RSP LWC2 pack-type operations and vector multiply-
  * accumulate going on here, doing some fancy matrix math from data memory.
  */
-static void packed_multiply_accumulate(pi32 acc, pi16 vs, pi16 vt, int offset)
+static void packed_multiply_accumulate(i32 * acc, i16 * vs, i16 * vt)
 {
 	i32 result;
 	register int i;
 
 	result = 0;
 	for (i = 0; i < 8; i++)
-		result += (s32)vs[i + offset] * (s32)vt[i];
+		result += (s32)vs[i] * (s32)vt[i];
 	*(acc) = result;
 	return;
 }
@@ -79,14 +79,14 @@ void FILTER2() {
 	swap_elements(&inputs_matrix[0]);
 
 	for (x = 0; x < cnt; x += 0x10) {
-		packed_multiply_accumulate(&out1[0], &inputs_matrix[0], &lutt6[0], 6);
-		packed_multiply_accumulate(&out1[1], &inputs_matrix[0], &lutt6[0], 7);
-		packed_multiply_accumulate(&out1[2], &inputs_matrix[0], &lutt6[0], 4);
-		packed_multiply_accumulate(&out1[3], &inputs_matrix[0], &lutt6[0], 5);
-		packed_multiply_accumulate(&out1[4], &inputs_matrix[0], &lutt6[0], 2);
-		packed_multiply_accumulate(&out1[5], &inputs_matrix[0], &lutt6[0], 3);
-		packed_multiply_accumulate(&out1[6], &inputs_matrix[0], &lutt6[0], 0);
-		packed_multiply_accumulate(&out1[7], &inputs_matrix[0], &lutt6[0], 1);
+		packed_multiply_accumulate(&out1[0], &inputs_matrix[6], &lutt6[0]);
+		packed_multiply_accumulate(&out1[1], &inputs_matrix[7], &lutt6[0]);
+		packed_multiply_accumulate(&out1[2], &inputs_matrix[4], &lutt6[0]);
+		packed_multiply_accumulate(&out1[3], &inputs_matrix[5], &lutt6[0]);
+		packed_multiply_accumulate(&out1[4], &inputs_matrix[2], &lutt6[0]);
+		packed_multiply_accumulate(&out1[5], &inputs_matrix[3], &lutt6[0]);
+		packed_multiply_accumulate(&out1[6], &inputs_matrix[0], &lutt6[0]);
+		packed_multiply_accumulate(&out1[7], &inputs_matrix[1], &lutt6[0]);
 
 		for (i = 0; i < 8; i++)
 			outp[i] = (out1[i] + 0x4000) >> 15; /* fractional round and shift */

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -18,11 +18,22 @@
 static void packed_multiply_accumulate(i32 * acc, i16 * vs, i16 * vt)
 {
 	i32 result;
+#ifdef SSE2_SUPPORT
+	__m128i xmm_source, xmm_target;
+	i32 pre_buffer[4];
+
+	xmm_source = _mm_loadu_si128((__m128i *)vs);
+	xmm_target = _mm_loadu_si128((__m128i *)vt);
+	xmm_source = _mm_madd_epi16(xmm_source, xmm_target);
+	_mm_storeu_si128((__m128i *)pre_buffer, xmm_source);
+	result = pre_buffer[0] + pre_buffer[1] + pre_buffer[2] + pre_buffer[3];
+#else
 	register int i;
 
 	result = 0;
 	for (i = 0; i < 8; i++)
 		result += (s32)vs[i] * (s32)vt[i];
+#endif
 	*(acc) = result;
 	return;
 }

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -409,3 +409,23 @@ INLINE void vsatu64 (u16* vd, s32* vs)
         vd[i] = pack_unsigned(vs[i]);
 }
 #endif
+
+void swap_elements(i16 * RSP_vector)
+{
+#ifdef SSE2_SUPPORT
+    __m128i RSP_as_XMM;
+
+    RSP_as_XMM = _mm_loadu_si128((__m128i *)RSP_vector);
+    RSP_as_XMM = _mm_shufflehi_epi16(RSP_as_XMM, _MM_SHUFFLE(2, 3, 0, 1));
+    RSP_as_XMM = _mm_shufflelo_epi16(RSP_as_XMM, _MM_SHUFFLE(2, 3, 0, 1));
+    _mm_storeu_si128((__m128i *)RSP_vector, RSP_as_XMM);
+#else
+    i16 temp_vector[8];
+    register size_t i;
+
+    for (i = 0; i < 8; i++)
+        temp_vector[i] = RSP_vector[i ^ 1];
+    for (i = 0; i < 8; i++)
+        RSP_vector[i] = temp_vector[i];
+#endif
+}

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -193,3 +193,13 @@ extern INLINE void vsatu64 (u16* vd, s32* vs);
 #define TWOS_COMPLEMENT_NEGATION
 #endif
 #endif
+
+/*
+ * Unfortunately, as most of the low-level details of RSP hardware came from
+ * the ultra-little-endian design from zilmar's RSP interpreter, much of RSP
+ * vector simulation in this HLE revolved around backwards element order.
+ *
+ * A quick fix to this is to have a function to switch the positions of
+ * adjacent 16-bit RSP vector elements with each other.
+ */
+extern void swap_elements(i16 * RSP_vector);


### PR DESCRIPTION
I ran these changes quickly by a full race in _Mario Kart 64_ and _Legend of Zelda:  Ocarina of Time_ and have yet to hear any audible differences, surprisingly.  I do find that surprising, since this is my very first time I have written SIMD using the unusual _mm_madd_epi16 intrinsic:  https://msdn.microsoft.com/en-us/library/yht36sa6%28v=vs.90%29.aspx
(See the fourth commit here for its installation.)

That is where the biggest performance gain comes in.  I'm not sure how much of a bottleneck this portion of RSP audio HLE is, but this function is VERY much faster without repeated scalar multiplies, followed by repeated scalar adds, within a function called 8 times, within a loop repeated at least 16 times.  Makes a big difference.  In fact, I see no remaining ways to increase the performance of this portion of ABI2 emulation that are of relative significance to the rest of the source.