### PR TITLE
Use s32/i32 instead of int, when size matters.

### DIFF
--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -192,9 +192,16 @@ void MP3AB0 () {
 	}
 }
 
-int CalcDeWindow(u32 addptr, int mp3DataIndex, u32 offset, int offsetValue)
+s32 CalcDeWindow(u32 addptr, int mp3DataIndex, u32 offset, int offsetValue)
 {
-	return ((int)*(s16 *)(mp3data + (addptr)+ mp3DataIndex) * (s16)DeWindowLUT[offset + offsetValue] + 0x4000) >> 0xF;
+    s32 product;
+
+    product =
+        (s32)*(s16 *)(mp3data + addptr + mp3DataIndex)
+      * (s32)(s16)DeWindowLUT[offset + offsetValue]
+    ;
+    product = (product + 0x4000) >> 15; /* single-precision fraction rounding */
+    return (product);
 }
 
 // ** Store v[vIndex] -> (mp3DataIndex)**

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -13,7 +13,7 @@
 
 u16 adpcmtable[0x88];
 
-void InitInput(s32 *inp, int index, u8 icode, u8 mask, u8 shifter, BYTE code, u8 srange, int vscale)
+void InitInput(s32 *inp, int index, u8 icode, u8 mask, u8 shifter, u8 code, u8 srange, int vscale)
 {
 	inp[index] = (s16)((icode & mask) << shifter);
 	if (code < srange)	
@@ -45,7 +45,6 @@ void ADPCM() { // Work in progress! :)
 	s16 *out = (s16 *)(BufferSpace + AudioOutBuffer);
 	u8 *in = (u8 *)(BufferSpace + AudioInBuffer);
 	s16 count = (s16)AudioCount;
-	BYTE code;
 	int vscale;
 	WORD index;
 	WORD j;
@@ -81,7 +80,7 @@ void ADPCM() { // Work in progress! :)
 		// area of memory in the case of A_LOOP or just
 		// the values we calculated the last time
 
-		code = BufferSpace[BES(AudioInBuffer + inPtr)];
+		u8 code = BufferSpace[BES(AudioInBuffer + inPtr)];
 		index = code & 0xf;
 		index <<= 4;									// index into the adpcm code table
 		book1 = (s16 *)&adpcmtable[index];
@@ -158,7 +157,6 @@ void ADPCM2() { // Verified to be 100% Accurate...
 	s16 *out = (s16 *)(BufferSpace + AudioOutBuffer);
 	u8 *in = (u8 *)(BufferSpace + AudioInBuffer);
 	s16 count = (s16)AudioCount;
-	BYTE code;
 	int vscale;
 	WORD index;
 	WORD j;
@@ -215,7 +213,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 	s32 inp2[8];
 	out += 16;
 	while (count>0) {
-		code = BufferSpace[BES(AudioInBuffer + inPtr)];
+		u8 code = BufferSpace[BES(AudioInBuffer + inPtr)];
 		index = code & 0xf;
 		index <<= 4;
 		book1 = (s16 *)&adpcmtable[index];
@@ -304,7 +302,6 @@ void ADPCM3() { // Verified to be 100% Accurate...
 	s16 *out = (s16 *)(BufferSpace + (t9 & 0xfff) + 0x4f0);
 	BYTE *in = (BYTE *)(BufferSpace + ((t9 >> 12) & 0xf) + 0x4f0);
 	s16 count = (s16)((t9 >> 16) & 0xfff);
-	BYTE code;
 	int vscale;
 	WORD index;
 	WORD j;
@@ -346,7 +343,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		// area of memory in the case of A_LOOP or just
 		// the values we calculated the last time
 
-		code = BufferSpace[BES(0x4f0 + inPtr)];
+		u8 code = BufferSpace[BES(0x4f0 + inPtr)];
 		index = code & 0xf;
 		index <<= 4;									// index into the adpcm code table
 		book1 = (s16 *)&adpcmtable[index];

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -86,7 +86,7 @@ void ADPCM() { // Work in progress! :)
 		book1 = (s16 *)&adpcmtable[index];
 		book2 = book1 + 8;
 		code >>= 4;									// upper nibble is scale
-		vscale = (0x8000 >> ((12 - code) - 1));			// very strange. 0x8000 would be .5 in 16:16 format
+		vscale = (0x8000u >> ((12 - code) - 1));		// very strange. 0x8000 would be .5 in 16:16 format
 		// so this appears to be a fractional scale based
 		// on the 12 based inverse of the scale value.  note
 		// that this could be negative, in which case we do
@@ -219,7 +219,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		book1 = (s16 *)&adpcmtable[index];
 		book2 = book1 + 8;
 		code >>= 4;
-		vscale = (0x8000 >> ((srange - code) - 1));
+		vscale = (0x8000u >> ((srange - code) - 1));
 
 		inPtr++;
 		j = 0;
@@ -349,7 +349,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		book1 = (s16 *)&adpcmtable[index];
 		book2 = book1 + 8;
 		code >>= 4;									// upper nibble is scale
-		vscale = (0x8000 >> ((12 - code) - 1));			// very strange. 0x8000 would be .5 in 16:16 format
+		vscale = (0x8000u >> ((12 - code) - 1));		// very strange. 0x8000 would be .5 in 16:16 format
 		// so this appears to be a fractional scale based
 		// on the 12 based inverse of the scale value.  note
 		// that this could be negative, in which case we do

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -13,7 +13,7 @@
 
 u16 adpcmtable[0x88];
 
-void InitInput(s32 *inp, int index, BYTE icode, u8 mask, u8 shifter, BYTE code, u8 srange, int vscale)
+void InitInput(s32 *inp, int index, u8 icode, u8 mask, u8 shifter, BYTE code, u8 srange, int vscale)
 {
 	inp[index] = (s16)((icode & mask) << shifter);
 	if (code < srange)	
@@ -45,7 +45,6 @@ void ADPCM() { // Work in progress! :)
 	s16 *out = (s16 *)(BufferSpace + AudioOutBuffer);
 	u8 *in = (u8 *)(BufferSpace + AudioInBuffer);
 	s16 count = (s16)AudioCount;
-	BYTE icode;
 	BYTE code;
 	int vscale;
 	WORD index;
@@ -100,7 +99,7 @@ void ADPCM() { // Work in progress! :)
 		while (j<8)									// loop of 8, for 8 coded nibbles from 4 bytes
 			// which yields 8 short pcm values
 		{
-			icode = BufferSpace[BES(AudioInBuffer + inPtr)];
+			u8 icode = BufferSpace[BES(AudioInBuffer + inPtr)];
 			inPtr++;
 
 			InitInput(inp1, j, icode, 0xf0, 8, code, 12, vscale); // this will in effect be signed
@@ -112,7 +111,7 @@ void ADPCM() { // Work in progress! :)
 		j = 0;
 		while (j<8)
 		{
-			icode = BufferSpace[BES(AudioInBuffer + inPtr)];
+			u8 icode = BufferSpace[BES(AudioInBuffer + inPtr)];
 			inPtr++;
 
 			InitInput(inp2, j, icode, 0xf0, 8, code, 12, vscale); // this will in effect be signed
@@ -159,7 +158,6 @@ void ADPCM2() { // Verified to be 100% Accurate...
 	s16 *out = (s16 *)(BufferSpace + AudioOutBuffer);
 	u8 *in = (u8 *)(BufferSpace + AudioInBuffer);
 	s16 count = (s16)AudioCount;
-	BYTE icode;
 	BYTE code;
 	int vscale;
 	WORD index;
@@ -229,7 +227,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		j = 0;
 
 		while (j<8) {
-			icode = BufferSpace[BES(AudioInBuffer + inPtr)];
+			u8 icode = BufferSpace[BES(AudioInBuffer + inPtr)];
 			inPtr++;
 
 			InitInput(inp1, j, icode, mask1, 8, code, srange, vscale); // this will in effect be signed
@@ -251,7 +249,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 		j = 0;
 		while (j<8) {
-			icode = BufferSpace[BES(AudioInBuffer + inPtr)];
+			u8 icode = BufferSpace[BES(AudioInBuffer + inPtr)];
 			inPtr++;
 
 			InitInput(inp2, j, icode, mask1, 8, code, srange, vscale);
@@ -306,7 +304,6 @@ void ADPCM3() { // Verified to be 100% Accurate...
 	s16 *out = (s16 *)(BufferSpace + (t9 & 0xfff) + 0x4f0);
 	BYTE *in = (BYTE *)(BufferSpace + ((t9 >> 12) & 0xf) + 0x4f0);
 	s16 count = (s16)((t9 >> 16) & 0xfff);
-	BYTE icode;
 	BYTE code;
 	int vscale;
 	WORD index;
@@ -367,7 +364,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		while (j<8)									// loop of 8, for 8 coded nibbles from 4 bytes
 			// which yields 8 short pcm values
 		{
-			icode = BufferSpace[BES(0x4f0 + inPtr)];
+			u8 icode = BufferSpace[BES(0x4f0 + inPtr)];
 			inPtr++;
 
 			InitInput(inp1, j, icode, 0xf0, 8, code, 12, vscale); // this will in effect be signed
@@ -379,7 +376,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		j = 0;
 		while (j<8)
 		{
-			icode = BufferSpace[BES(0x4f0 + inPtr)];
+			u8 icode = BufferSpace[BES(0x4f0 + inPtr)];
 			inPtr++;
 
 			InitInput(inp2, j, icode, 0xf0, 8, code, 12, vscale); // this will in effect be signed

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -13,26 +13,26 @@
 
 u16 adpcmtable[0x88];
 
-void InitInput(int *inp, int index, BYTE icode, u8 mask, u8 shifter, BYTE code, u8 srange, int vscale)
+void InitInput(s32 *inp, int index, BYTE icode, u8 mask, u8 shifter, BYTE code, u8 srange, int vscale)
 {
 	inp[index] = (s16)((icode & mask) << shifter);
 	if (code < srange)	
-		inp[index] = ((int)((int)inp[index] * (int)vscale) >> 16);
+		inp[index] = (inp[index] * vscale) >> 16;
 	else 
 		int catchme = 1;
 }
 
-void ADPCMFillArray(int *a, s16* book1, s16* book2, int l1, int l2, int *inp)
+void ADPCMFillArray(s32 *a, s16* book1, s16* book2, s32 l1, s32 l2, s32 *inp)
 {
 	for (int i = 0; i < 8; i++)
 	{
-		a[i] = (int)book1[i] * (int)l1;
-		a[i] += (int)book2[i] * (int)l2;
+		a[i]  = (s32)book1[i] * (s32)l1;
+		a[i] += (s32)book2[i] * (s32)l2;
 		for (int i2 = 0; i2 < i; i2++)
 		{
-			a[i] += (int)book2[(i - 1) - i2] * inp[i2];
+			a[i] += (s32)book2[(i - 1) - i2] * inp[i2];
 		}
-		a[i] += (int)inp[i] * (int)2048;
+		a[i] += 2048 * inp[i];
 	}
 }
 
@@ -50,7 +50,7 @@ void ADPCM() { // Work in progress! :)
 	int vscale;
 	WORD index;
 	WORD j;
-	int a[8];
+	s32 a[8];
 	s16* book1;
 	s16* book2;
 
@@ -70,10 +70,10 @@ void ADPCM() { // Work in progress! :)
 		}
 	}
 
-	int l1 = out[15];
-	int l2 = out[14];
-	int inp1[8];
-	int inp2[8];
+	s32 l1 = out[15];
+	s32 l2 = out[14];
+	s32 inp1[8];
+	s32 inp2[8];
 	out += 16;
 	while (count>0)
 	{
@@ -164,7 +164,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 	int vscale;
 	WORD index;
 	WORD j;
-	int a[8];
+	s32 a[8];
 	s16* book1;
 	s16* book2;
 
@@ -211,10 +211,10 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		}
 	}
 
-	int l1 = out[15];
-	int l2 = out[14];
-	int inp1[8];
-	int inp2[8];
+	s32 l1 = out[15];
+	s32 l2 = out[14];
+	s32 inp1[8];
+	s32 inp2[8];
 	out += 16;
 	while (count>0) {
 		code = BufferSpace[BES(AudioInBuffer + inPtr)];
@@ -311,7 +311,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 	int vscale;
 	WORD index;
 	WORD j;
-	int a[8];
+	s32 a[8];
 	s16* book1;
 	s16* book2;
 
@@ -337,10 +337,10 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		}
 	}
 
-	int l1 = out[15];
-	int l2 = out[14];
-	int inp1[8];
-	int inp2[8];
+	s32 l1 = out[15];
+	s32 l2 = out[14];
+	s32 inp1[8];
+	s32 inp2[8];
 	out += 16;
 	while (count>0)
 	{

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -127,7 +127,7 @@ void ENVMIXER() {
 	s32 MainL;
 	s32 AuxR;
 	s32 AuxL;
-	int i1, o1, a1, a2, a3;
+	s32 i1, o1, a1, a2, a3;
 	WORD AuxIncRate = 1;
 	s16 zero[8];
 	memset(zero, 0, sizeof(s16) * 8);
@@ -200,12 +200,12 @@ void ENVMIXER() {
 		}
 
 		for (int x = 0; x < 8; x++) {
-			i1 = (int)inp[MES(ptr)];
-			o1 = (int)out[MES(ptr)];
-			a1 = (int)aux1[MES(ptr)];
+			i1 = inp[MES(ptr)];
+			o1 = out[MES(ptr)];
+			a1 = aux1[MES(ptr)];
 			if (AuxIncRate) {
-				a2 = (int)aux2[MES(ptr)];
-				a3 = (int)aux3[MES(ptr)];
+				a2 = aux2[MES(ptr)];
+				a3 = aux3[MES(ptr)];
 			}
 			// TODO: here...
 			//LAcc = LTrg;
@@ -447,7 +447,7 @@ void ENVMIXER3() {
 	s32 MainL;
 	s32 AuxR;
 	s32 AuxL;
-	int i1, o1, a1, a2, a3;
+	s32 i1, o1, a1, a2, a3;
 	WORD AuxIncRate = 1;
 	s16 zero[8];
 	memset(zero, 0, sizeof(s16) * 8);


### PR DESCRIPTION
Several places throughout the source is the `int` data type, where at least 32 bits of precision is needed.  (For example, sometimes the plugin loads an `int` with a 16-bit data type, but later throughout the source accumulates it with 32-bit products from multiplying other elements, in which case we still require 32 bits.)

Again further regression-testing will likely be necessary here, which I have not yet completed.

The only way that saying `int` instead of `int32_t`/`s32`/whatever can be guaranteed to be safe in all cases is by the C89 rule that if you're storing something between -32768 to +32767 (in a 16-bit range), it's required to fit into an `int`.  Still, that's not a very self-explanatory thing, and if 32 bits are required we should indeed have a 32-bit type.  (Preferably a *custom* 32-bit type that isn't fused into C99's skin of modern futuristic notions of arbitrary features compiled into the language itself, which we've accomplished.)

Similar to this pull request is a last commit I did to the pull request here:  https://github.com/Azimer/AziAudio/pull/58 ... where I replaced `short` with `s16` where size matters.