### PR TITLE
Refer to RSP hardware operation `SH` when storing halfwords.

### DIFF
--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -198,11 +198,24 @@ int CalcDeWindow(u32 addptr, int mp3DataIndex, u32 offset, int offsetValue)
 }
 
 // ** Store v[vIndex] -> (mp3DataIndex)**
-void StoreData(s32 vIndex, int mp3DataIndex)
+static void rsp_SH(int rt, s16 offset, u32 base)
 {
-	*(s16 *)(mp3data + mp3DataIndex) = (s16)v[vIndex];
-}
+    u8 * DMEM;
+    u32 address;
 
+    address = base + offset; /* u32 base == GPR[base] */
+#if 1
+    assert((address & ~0xFFFul) == 0);
+#else
+    address = address & 0x00000FFFu;
+#endif
+
+    DMEM = &mp3data[0]; /* mp3data[] has exactly 4096 bytes allocated. */
+#if 1
+    assert((address & 1) == 0);
+#endif
+    *(s16 *)(DMEM + address) = (s16)(v[rt] & 0x0000FFFFul);
+}
 
 void InnerLoop ();
 
@@ -312,26 +325,26 @@ void InnerLoop () {
 	v[16] = -v[16] - v[17];
 	v[ 2] =  v[18] + v[19];
 	// ** Store v[11] -> (T6 + 0)**
-	StoreData(11, (t6 + (s16)0x0000));
+	rsp_SH(11, 0x0000, t6);
 
 	v[11] = -v[11];
 	// ** Store v[16] -> (T3 + 0)**
-	StoreData(16, (t3 + (s16)0x0000));
+	rsp_SH(16, 0x0000, t3);
 	// ** Store v[11] -> (T5 + 0)**
-	StoreData(11, (t5 + (s16)0x0000));
+	rsp_SH(11, 0x0000, t5);
 	// 0x13E8 - Verified....
 	v[2] = -v[2];
 	// ** Store v[2] -> (T2 + 0)**
-	StoreData(2, (t2 + (s16)0x0000));
+	rsp_SH( 2, 0x0000, t2);
 	v[3]  = (((v[18] - v[19]) * 0x16A09) >> 0x10) + v[2];
 	// ** Store v[3] -> (T0 + 0)**
-	StoreData(3, (t0 + (s16)0x0000));
+	rsp_SH( 3, 0x0000, t0);
 	// 0x1400 - Verified
 	v[4] = -v[20] - v[21];
 	v[6] =  v[22] + v[23];
 	v[5] = ((v[20] - v[21]) * 0x16A09) >> 0x10;
 	// ** Store v[4] -> (T3 + 0xFF80)
-	StoreData(4, (t3 + (s16)0xFF80));
+	rsp_SH( 4, 0xFF80, t3);
 	v[7] = ((v[22] - v[23]) * 0x2D413) >> 0x10;
 	v[5] =  v[5] - v[4];
 	v[7] =  v[7] - v[5];
@@ -339,11 +352,11 @@ void InnerLoop () {
 	v[5] =  v[5] - v[6];
 	v[4] = -v[4] - v[6];
 	// *** Store v[7] -> (T1 + 0xFF80)
-	StoreData(7, (t1 + (s16)0xFF80));
+	rsp_SH( 7, 0xFF80, t1);
 	// *** Store v[4] -> (T2 + 0xFF80)
-	StoreData(4, (t2 + (s16)0xFF80));
+	rsp_SH( 4, 0xFF80, t2);
 	// *** Store v[5] -> (T0 + 0xFF80)
-	StoreData(5, (t0 + (s16)0xFF80));
+	rsp_SH( 5, 0xFF80, t0);
 	v[ 8] = v[24] + v[25];
 
 	v[ 9] = ((v[24] - v[25]) * 0x16A09) >> 0x10;
@@ -362,25 +375,25 @@ void InnerLoop () {
 	v[17] = v[13] - v[10];
 	v[ 9] = v[9] + v[14];
 	// ** Store v[9] -> (T6 + 0x40)
-	StoreData(9, (t6 + (s16)0x0040));
+	rsp_SH( 9, 0x0040, t6);
 	v[11] = v[11] - v[13];
 	// ** Store v[17] -> (T0 + 0xFFC0)
-	StoreData(17, (t0 + (s16)0xFFC0));
+	rsp_SH(17, 0xFFC0, t0);
 	v[12] = v[8] - v[12];
 	// ** Store v[11] -> (T0 + 0x40)
-	StoreData(11, (t0 + (s16)0x0040));
+	rsp_SH(11, 0x0040, t0);
 	v[8] = -v[8];
 	// ** Store v[15] -> (T1 + 0xFFC0)
-	StoreData(15, (t1 + (s16)0xFFC0));
+	rsp_SH(15, 0xFFC0, t1);
 	v[10] = -v[10] -v[12];
 	// ** Store v[12] -> (T2 + 0x40)
-	StoreData(12, (t2 + (s16)0x0040));
+	rsp_SH(12, 0x0040, t2);
 	// ** Store v[8] -> (T3 + 0xFFC0)
-	StoreData(8, (t3 + (s16)0xFFC0));
+	rsp_SH( 8, 0xFFC0, t3);
 	// ** Store v[14] -> (T5 + 0x40)
-	StoreData(14, (t5 + (s16)0x0040));
+	rsp_SH(14, 0x0040, t5);
 	// ** Store v[10] -> (T2 + 0xFFC0)
-	StoreData(10, (t2 + (s16)0xFFC0));
+	rsp_SH(10, 0xFFC0, t2);
 	// 0x14FC - Verified...
 
 	// Part 6 - 100% Accurate
@@ -438,7 +451,7 @@ void InnerLoop () {
 	v[11] = (((v[26] - v[27]) * 0x2D413) >> 0x10) + v[8] + v[9];
 	v[12] = v[4] - ((v[28] + v[29]) << 1);
 	// ** Store v12 -> (T2 + 0x20)
-	StoreData(12, (t2 + (s16)0x0020));
+	rsp_SH(12, 0x0020, t2);
 	v[13] = (((v[28] - v[29]) * 0x2D413) >> 0x10) - v[12] - v[5];
 	v[14] = v[30] + v[31];
 	v[14] = v[14] + v[14];
@@ -446,51 +459,51 @@ void InnerLoop () {
 	v[14] = v[ 6] - v[14];
 	v[15] = (((v[30] - v[31]) * 0x5A827) >> 0x10) - v[7];
 	// Store v14 -> (T5 + 0x20)
-	StoreData(14, (t5 + (s16)0x0020));
+	rsp_SH(14, 0x0020, t5);
 	v[14] = v[14] + v[1];
 	// Store v[14] -> (T6 + 0x20)
-	StoreData(14, (t6 + (s16)0x0020));
+	rsp_SH(14, 0x0020, t6);
 	// Store v[15] -> (T1 + 0xFFE0)
-	StoreData(15, (t1 + (s16)0xFFE0));
+	rsp_SH(15, 0xFFE0, t1);
 	v[9] = v[ 9] + v[10];
 	v[1] = v[ 1] + v[ 6];
 	v[6] = v[10] - v[ 6];
 	v[1] = v[ 9] - v[ 1];
 	// Store v[6] -> (T5 + 0x60)
-	StoreData(6, (t5 + (s16)0x0060));
+	rsp_SH( 6, 0x0060, t5);
 	v[10] = v[10] + v[ 2];
 	v[10] = v[ 4] - v[10];
 	// Store v[10] -> (T2 + 0xFFA0)
-	StoreData(10, (t2 + (s16)0xFFA0));
+	rsp_SH(10, 0xFFA0, t2);
 	v[12] = v[2] - v[12];
 	// Store v[12] -> (T2 + 0xFFE0)
-	StoreData(12, (t2 + (s16)0xFFE0));
+	rsp_SH(12, 0xFFE0, t2);
 	v[5] = v[4] + v[5];
 	v[4] = v[8] - v[4];
 	// Store v[4] -> (T2 + 0x60)
-	StoreData(4, (t2 + (s16)0x0060));
+	rsp_SH( 4, 0x0060, t2);
 	v[0] = v[0] - v[8];
 	// Store v[0] -> (T3 + 0xFFA0)
-	StoreData(0, (t3 + (s16)0xFFA0));
+	rsp_SH( 0, 0xFFA0, t3);
 	v[7] = v[7] - v[11];
 	// Store v[7] -> (T1 + 0xFFA0)
-	StoreData(7, (t1 + (s16)0xFFA0));
+	rsp_SH( 7, 0xFFA0, t1);
 	v[11] = v[11] - v[3];
 	// Store v[1] -> (T6 + 0x60)
-	StoreData(1, (t6 + (s16)0x0060));
+	rsp_SH( 1, 0x0060, t6);
 	v[11] = v[11] - v[5];
 	// Store v[11] -> (T0 + 0x60)
-	StoreData(11, (t0 + (s16)0x0060));
+	rsp_SH(11, 0x0060, t0);
 	v[3] = v[3] - v[13];
 	// Store v[3] -> (T0 + 0x20)
-	StoreData(3, (t0 + (s16)0x0020));
+	rsp_SH( 3, 0x0020, t0);
 	v[13] = v[13] + v[2];
 	// Store v[13] -> (T0 + 0xFFE0)
-	StoreData(13, (t0 + (s16)0xFFE0));
+	rsp_SH(13, 0xFFE0, t0);
 	//v[2] = ;
 	v[2] = (v[5] - v[2]) - v[9];
 	// Store v[2] -> (T0 + 0xFFA0)
-	StoreData(2, (t0 + (s16)0xFFA0));
+	rsp_SH( 2, 0xFFA0, t0);
 	// 0x7A8 - Verified...
 
 	// Step 8 - Dewindowing

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -204,14 +204,12 @@ static void rsp_SH(int rt, s16 offset, u32 base)
     u32 address;
 
     address = base + offset; /* u32 base == GPR[base] */
-#if 1
+#if 0
     assert((address & ~0xFFFul) == 0);
-#else
-    address = address & 0x00000FFFu;
 #endif
 
     DMEM = &mp3data[0]; /* mp3data[] has exactly 4096 bytes allocated. */
-#if 1
+#if 0
     assert((address & 1) == 0);
 #endif
     *(s16 *)(DMEM + address) = (s16)(v[rt] & 0x0000FFFFul);

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -322,26 +322,20 @@ void InnerLoop () {
 
 	v[16] = -v[16] - v[17];
 	v[ 2] =  v[18] + v[19];
-	// ** Store v[11] -> (T6 + 0)**
 	rsp_SH(11, 0x0000, t6);
-
 	v[11] = -v[11];
-	// ** Store v[16] -> (T3 + 0)**
 	rsp_SH(16, 0x0000, t3);
-	// ** Store v[11] -> (T5 + 0)**
 	rsp_SH(11, 0x0000, t5);
+
 	// 0x13E8 - Verified....
 	v[2] = -v[2];
-	// ** Store v[2] -> (T2 + 0)**
 	rsp_SH( 2, 0x0000, t2);
 	v[3]  = (((v[18] - v[19]) * 0x16A09) >> 0x10) + v[2];
-	// ** Store v[3] -> (T0 + 0)**
 	rsp_SH( 3, 0x0000, t0);
 	// 0x1400 - Verified
 	v[4] = -v[20] - v[21];
 	v[6] =  v[22] + v[23];
 	v[5] = ((v[20] - v[21]) * 0x16A09) >> 0x10;
-	// ** Store v[4] -> (T3 + 0xFF80)
 	rsp_SH( 4, 0xFF80, t3);
 	v[7] = ((v[22] - v[23]) * 0x2D413) >> 0x10;
 	v[5] =  v[5] - v[4];
@@ -349,11 +343,8 @@ void InnerLoop () {
 	v[6] =  v[6] + v[6];
 	v[5] =  v[5] - v[6];
 	v[4] = -v[4] - v[6];
-	// *** Store v[7] -> (T1 + 0xFF80)
 	rsp_SH( 7, 0xFF80, t1);
-	// *** Store v[4] -> (T2 + 0xFF80)
 	rsp_SH( 4, 0xFF80, t2);
-	// *** Store v[5] -> (T0 + 0xFF80)
 	rsp_SH( 5, 0xFF80, t0);
 	v[ 8] = v[24] + v[25];
 
@@ -372,25 +363,17 @@ void InnerLoop () {
 	v[14] = -(v[14] + v[14]) + v[3];
 	v[17] = v[13] - v[10];
 	v[ 9] = v[9] + v[14];
-	// ** Store v[9] -> (T6 + 0x40)
 	rsp_SH( 9, 0x0040, t6);
 	v[11] = v[11] - v[13];
-	// ** Store v[17] -> (T0 + 0xFFC0)
 	rsp_SH(17, 0xFFC0, t0);
 	v[12] = v[8] - v[12];
-	// ** Store v[11] -> (T0 + 0x40)
 	rsp_SH(11, 0x0040, t0);
 	v[8] = -v[8];
-	// ** Store v[15] -> (T1 + 0xFFC0)
 	rsp_SH(15, 0xFFC0, t1);
 	v[10] = -v[10] -v[12];
-	// ** Store v[12] -> (T2 + 0x40)
 	rsp_SH(12, 0x0040, t2);
-	// ** Store v[8] -> (T3 + 0xFFC0)
 	rsp_SH( 8, 0xFFC0, t3);
-	// ** Store v[14] -> (T5 + 0x40)
 	rsp_SH(14, 0x0040, t5);
-	// ** Store v[10] -> (T2 + 0xFFC0)
 	rsp_SH(10, 0xFFC0, t2);
 	// 0x14FC - Verified...
 
@@ -448,7 +431,6 @@ void InnerLoop () {
 	v[10] = ((v[26] + v[27]) << 1) + v[8];
 	v[11] = (((v[26] - v[27]) * 0x2D413) >> 0x10) + v[8] + v[9];
 	v[12] = v[4] - ((v[28] + v[29]) << 1);
-	// ** Store v12 -> (T2 + 0x20)
 	rsp_SH(12, 0x0020, t2);
 	v[13] = (((v[28] - v[29]) * 0x2D413) >> 0x10) - v[12] - v[5];
 	v[14] = v[30] + v[31];
@@ -456,51 +438,37 @@ void InnerLoop () {
 	v[14] = v[14] + v[14];
 	v[14] = v[ 6] - v[14];
 	v[15] = (((v[30] - v[31]) * 0x5A827) >> 0x10) - v[7];
-	// Store v14 -> (T5 + 0x20)
 	rsp_SH(14, 0x0020, t5);
 	v[14] = v[14] + v[1];
-	// Store v[14] -> (T6 + 0x20)
 	rsp_SH(14, 0x0020, t6);
-	// Store v[15] -> (T1 + 0xFFE0)
 	rsp_SH(15, 0xFFE0, t1);
 	v[9] = v[ 9] + v[10];
 	v[1] = v[ 1] + v[ 6];
 	v[6] = v[10] - v[ 6];
 	v[1] = v[ 9] - v[ 1];
-	// Store v[6] -> (T5 + 0x60)
 	rsp_SH( 6, 0x0060, t5);
 	v[10] = v[10] + v[ 2];
 	v[10] = v[ 4] - v[10];
-	// Store v[10] -> (T2 + 0xFFA0)
 	rsp_SH(10, 0xFFA0, t2);
 	v[12] = v[2] - v[12];
-	// Store v[12] -> (T2 + 0xFFE0)
 	rsp_SH(12, 0xFFE0, t2);
 	v[5] = v[4] + v[5];
 	v[4] = v[8] - v[4];
-	// Store v[4] -> (T2 + 0x60)
 	rsp_SH( 4, 0x0060, t2);
 	v[0] = v[0] - v[8];
-	// Store v[0] -> (T3 + 0xFFA0)
 	rsp_SH( 0, 0xFFA0, t3);
 	v[7] = v[7] - v[11];
-	// Store v[7] -> (T1 + 0xFFA0)
 	rsp_SH( 7, 0xFFA0, t1);
 	v[11] = v[11] - v[3];
-	// Store v[1] -> (T6 + 0x60)
 	rsp_SH( 1, 0x0060, t6);
 	v[11] = v[11] - v[5];
-	// Store v[11] -> (T0 + 0x60)
 	rsp_SH(11, 0x0060, t0);
 	v[3] = v[3] - v[13];
-	// Store v[3] -> (T0 + 0x20)
 	rsp_SH( 3, 0x0020, t0);
 	v[13] = v[13] + v[2];
-	// Store v[13] -> (T0 + 0xFFE0)
 	rsp_SH(13, 0xFFE0, t0);
 	//v[2] = ;
 	v[2] = (v[5] - v[2]) - v[9];
-	// Store v[2] -> (T0 + 0xFFA0)
 	rsp_SH( 2, 0xFFA0, t0);
 	// 0x7A8 - Verified...
 


### PR DESCRIPTION
Thanks to samuelyuan we now have already a functional allocation of the repeated behavior of storing the MP3 data as 16-bit segments.  However, the function bears such a striking resemblance to the SH op-code on the RSP, that I felt like re-doing this function to match the syntax of the SH instruction.

SH (store halfword) has the RSP assembly language syntax:
```asm
SH      $rt, +/-offset($base)
```
Naturally since SP DMEM has only 4096 (0xFFF + 1) bytes, whether the offset is positive signed or negative signed isn't exactly significant (could be either an offset of -1 or 0xFFFF, or just 0xFFF for +4095 and still end up meaning the same operation); however that doesn't change the fact that it's still a s16.  I wanted to emulate this in the new function.

As stated in a commit I've tested these changes with Conker's Bad Fur Day...which seems to only ever do aligned SH, not to mention the interesting coincidence that (base + offset) never sets bits outside of ~0x00000FFF which would have caused an access violation for out-of-bounds memory in Azimer's plugin.  So interestingly, the assert's were never needed in the game and I removed them.  Do feel free please to do the usual regression-testing as necessary in case there are other games/cases I don't know about.