### PR TITLE
Buffer ADPCM 128 bits at a time, rather than 16 bits at a time.

### DIFF
--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -423,18 +423,17 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[0];
-		adpcmtable[8*x + 0x0] = table[1];
+		adpcmtable[8*x + 0x1] = table[8*x + 0];
+		adpcmtable[8*x + 0x0] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[2];
-		adpcmtable[8*x + 0x2] = table[3];
+		adpcmtable[8*x + 0x3] = table[8*x + 2];
+		adpcmtable[8*x + 0x2] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[4];
-		adpcmtable[8*x + 0x4] = table[5];
+		adpcmtable[8*x + 0x5] = table[8*x + 4];
+		adpcmtable[8*x + 0x4] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[6];
-		adpcmtable[8*x + 0x6] = table[7];
-		table += 8;
+		adpcmtable[8*x + 0x7] = table[8*x + 6];
+		adpcmtable[8*x + 0x6] = table[8*x + 7];
 	}
 }
 
@@ -444,18 +443,17 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[0];
-		adpcmtable[8*x + 0x0] = table[1];
+		adpcmtable[8*x + 0x1] = table[8*x + 0];
+		adpcmtable[8*x + 0x0] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[2];
-		adpcmtable[8*x + 0x2] = table[3];
+		adpcmtable[8*x + 0x3] = table[8*x + 2];
+		adpcmtable[8*x + 0x2] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[4];
-		adpcmtable[8*x + 0x4] = table[5];
+		adpcmtable[8*x + 0x5] = table[8*x + 4];
+		adpcmtable[8*x + 0x4] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[6];
-		adpcmtable[8*x + 0x6] = table[7];
-		table += 8;
+		adpcmtable[8*x + 0x7] = table[8*x + 6];
+		adpcmtable[8*x + 0x6] = table[8*x + 7];
 	}
 }
 
@@ -466,17 +464,16 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[0];
-		adpcmtable[8*x + 0x0] = table[1];
+		adpcmtable[8*x + 0x1] = table[8*x + 0];
+		adpcmtable[8*x + 0x0] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[2];
-		adpcmtable[8*x + 0x2] = table[3];
+		adpcmtable[8*x + 0x3] = table[8*x + 2];
+		adpcmtable[8*x + 0x2] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[4];
-		adpcmtable[8*x + 0x4] = table[5];
+		adpcmtable[8*x + 0x5] = table[8*x + 4];
+		adpcmtable[8*x + 0x4] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[6];
-		adpcmtable[8*x + 0x6] = table[7];
-		table += 8;
+		adpcmtable[8*x + 0x7] = table[8*x + 6];
+		adpcmtable[8*x + 0x6] = table[8*x + 7];
 	}
 }

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -422,10 +422,8 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		copy_vector(&adpcmtable[8*x], &table[8*x]);
-		swap_elements((i16 *)&adpcmtable[8*x]);
-	}
+	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
+		swap_elements(&adpcmtable[8*x], &table[8*x]);
 }
 
 void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
@@ -433,10 +431,8 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		copy_vector(&adpcmtable[8*x], &table[8*x]);
-		swap_elements((i16 *)&adpcmtable[8*x]);
-	}
+	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
+		swap_elements(&adpcmtable[8*x], &table[8*x]);
 }
 
 void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
@@ -445,8 +441,6 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		copy_vector(&adpcmtable[8*x], &table[8*x]);
-		swap_elements((i16 *)&adpcmtable[8*x]);
-	}
+	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
+		swap_elements(&adpcmtable[8*x], &table[8*x]);
 }

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -416,31 +416,42 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
+	size_t i, limit;
+
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 	//	if (v0 > (1024*1024*8))
 	//		v0 = (t9 & 0xffffff);
 	//	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
-		swap_elements(&adpcmtable[8*x], &table[8*x]);
+
+	limit = (k0 & 0x0000FFFF) >> 4;
+	for (i = 0; i < limit; i++)
+		swap_elements(&adpcmtable[8*i], &table[8*i]);
 }
 
 void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
+	size_t i, limit;
+
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
-		swap_elements(&adpcmtable[8*x], &table[8*x]);
+	limit = (k0 & 0x0000FFFF) >> 4;
+	for (i = 0; i < limit; i++)
+		swap_elements(&adpcmtable[8*i], &table[8*i]);
 }
 
 void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u32 v0;
+	size_t i, limit;
+
 	v0 = (t9 & 0xffffff);
 	//memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
-	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++)
-		swap_elements(&adpcmtable[8*x], &table[8*x]);
+
+	limit = (k0 & 0x0000FFFF) >> 4;
+	for (i = 0; i < limit; i++)
+		swap_elements(&adpcmtable[8*i], &table[8*i]);
 }

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -423,17 +423,17 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[8*x + 0];
-		adpcmtable[8*x + 0x0] = table[8*x + 1];
+		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
+		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[8*x + 2];
-		adpcmtable[8*x + 0x2] = table[8*x + 3];
+		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
+		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[8*x + 4];
-		adpcmtable[8*x + 0x4] = table[8*x + 5];
+		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
+		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[8*x + 6];
-		adpcmtable[8*x + 0x6] = table[8*x + 7];
+		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
+		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
 	}
 }
 
@@ -443,17 +443,17 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[8*x + 0];
-		adpcmtable[8*x + 0x0] = table[8*x + 1];
+		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
+		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[8*x + 2];
-		adpcmtable[8*x + 0x2] = table[8*x + 3];
+		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
+		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[8*x + 4];
-		adpcmtable[8*x + 0x4] = table[8*x + 5];
+		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
+		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[8*x + 6];
-		adpcmtable[8*x + 0x6] = table[8*x + 7];
+		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
+		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
 	}
 }
 
@@ -464,16 +464,16 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + 0x1] = table[8*x + 0];
-		adpcmtable[8*x + 0x0] = table[8*x + 1];
+		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
+		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
 
-		adpcmtable[8*x + 0x3] = table[8*x + 2];
-		adpcmtable[8*x + 0x2] = table[8*x + 3];
+		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
+		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
 
-		adpcmtable[8*x + 0x5] = table[8*x + 4];
-		adpcmtable[8*x + 0x4] = table[8*x + 5];
+		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
+		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
 
-		adpcmtable[8*x + 0x7] = table[8*x + 6];
-		adpcmtable[8*x + 0x6] = table[8*x + 7];
+		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
+		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
 	}
 }

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -423,17 +423,8 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
-		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
-
-		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
-		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
-
-		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
-		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
-
-		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
-		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
+		copy_vector(&adpcmtable[8*x], &table[8*x]);
+		swap_elements((i16 *)&adpcmtable[8*x]);
 	}
 }
 
@@ -443,17 +434,8 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
-		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
-
-		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
-		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
-
-		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
-		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
-
-		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
-		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
+		copy_vector(&adpcmtable[8*x], &table[8*x]);
+		swap_elements((i16 *)&adpcmtable[8*x]);
 	}
 }
 
@@ -464,16 +446,7 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[8*x + (0 ^ 1)] = table[8*x + 0];
-		adpcmtable[8*x + (1 ^ 1)] = table[8*x + 1];
-
-		adpcmtable[8*x + (2 ^ 1)] = table[8*x + 2];
-		adpcmtable[8*x + (3 ^ 1)] = table[8*x + 3];
-
-		adpcmtable[8*x + (4 ^ 1)] = table[8*x + 4];
-		adpcmtable[8*x + (5 ^ 1)] = table[8*x + 5];
-
-		adpcmtable[8*x + (6 ^ 1)] = table[8*x + 6];
-		adpcmtable[8*x + (7 ^ 1)] = table[8*x + 7];
+		copy_vector(&adpcmtable[8*x], &table[8*x]);
+		swap_elements((i16 *)&adpcmtable[8*x]);
 	}
 }

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -423,17 +423,17 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//	assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[0x1 + (x << 3)] = table[0];
-		adpcmtable[0x0 + (x << 3)] = table[1];
+		adpcmtable[8*x + 0x1] = table[0];
+		adpcmtable[8*x + 0x0] = table[1];
 
-		adpcmtable[0x3 + (x << 3)] = table[2];
-		adpcmtable[0x2 + (x << 3)] = table[3];
+		adpcmtable[8*x + 0x3] = table[2];
+		adpcmtable[8*x + 0x2] = table[3];
 
-		adpcmtable[0x5 + (x << 3)] = table[4];
-		adpcmtable[0x4 + (x << 3)] = table[5];
+		adpcmtable[8*x + 0x5] = table[4];
+		adpcmtable[8*x + 0x4] = table[5];
 
-		adpcmtable[0x7 + (x << 3)] = table[6];
-		adpcmtable[0x6 + (x << 3)] = table[7];
+		adpcmtable[8*x + 0x7] = table[6];
+		adpcmtable[8*x + 0x6] = table[7];
 		table += 8;
 	}
 }
@@ -444,17 +444,17 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
 
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[0x1 + (x << 3)] = table[0];
-		adpcmtable[0x0 + (x << 3)] = table[1];
+		adpcmtable[8*x + 0x1] = table[0];
+		adpcmtable[8*x + 0x0] = table[1];
 
-		adpcmtable[0x3 + (x << 3)] = table[2];
-		adpcmtable[0x2 + (x << 3)] = table[3];
+		adpcmtable[8*x + 0x3] = table[2];
+		adpcmtable[8*x + 0x2] = table[3];
 
-		adpcmtable[0x5 + (x << 3)] = table[4];
-		adpcmtable[0x4 + (x << 3)] = table[5];
+		adpcmtable[8*x + 0x5] = table[4];
+		adpcmtable[8*x + 0x4] = table[5];
 
-		adpcmtable[0x7 + (x << 3)] = table[6];
-		adpcmtable[0x6 + (x << 3)] = table[7];
+		adpcmtable[8*x + 0x7] = table[6];
+		adpcmtable[8*x + 0x6] = table[7];
 		table += 8;
 	}
 }
@@ -466,17 +466,17 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//assert ((k0&0xffff) <= 0x80);
 	u16 *table = (u16 *)(rdram + v0);
 	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
-		adpcmtable[0x1 + (x << 3)] = table[0];
-		adpcmtable[0x0 + (x << 3)] = table[1];
+		adpcmtable[8*x + 0x1] = table[0];
+		adpcmtable[8*x + 0x0] = table[1];
 
-		adpcmtable[0x3 + (x << 3)] = table[2];
-		adpcmtable[0x2 + (x << 3)] = table[3];
+		adpcmtable[8*x + 0x3] = table[2];
+		adpcmtable[8*x + 0x2] = table[3];
 
-		adpcmtable[0x5 + (x << 3)] = table[4];
-		adpcmtable[0x4 + (x << 3)] = table[5];
+		adpcmtable[8*x + 0x5] = table[4];
+		adpcmtable[8*x + 0x4] = table[5];
 
-		adpcmtable[0x7 + (x << 3)] = table[6];
-		adpcmtable[0x6 + (x << 3)] = table[7];
+		adpcmtable[8*x + 0x7] = table[6];
+		adpcmtable[8*x + 0x6] = table[7];
 		table += 8;
 	}
 }

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -86,10 +86,10 @@ void FILTER2() {
  */
 	for (i = 0; i < 8; i++)
 		inputs_matrix[15 - (i + 0)] = inp1[i];
-	swap_elements(&inputs_matrix[8]);
+	swap_elements(&inputs_matrix[8], &inputs_matrix[8]);
 	for (i = 0; i < 8; i++)
 		inputs_matrix[15 - (i + 8)] = inp2[i];
-	swap_elements(&inputs_matrix[0]);
+	swap_elements(&inputs_matrix[0], &inputs_matrix[0]);
 
 	for (x = 0; x < cnt; x += 0x10) {
 		packed_multiply_accumulate(&out1[0], &inputs_matrix[6], &lutt6[0]);
@@ -121,8 +121,8 @@ void FILTER2() {
 
 		for (i = 0; i < 16; i++)
 			inputs_matrix[15 - i] = inp1[i];
-		swap_elements(&inputs_matrix[0]);
-		swap_elements(&inputs_matrix[8]);
+		swap_elements(&inputs_matrix[0], &inputs_matrix[0]);
+		swap_elements(&inputs_matrix[8], &inputs_matrix[8]);
 	}
 	//			memcpy (rdram+(t9&0xFFFFFF), dmem+0xFB0, 0x20);
 	memcpy(save, inp2 - 8, 0x10);

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -410,6 +410,23 @@ INLINE void vsatu64 (u16* vd, s32* vs)
 }
 #endif
 
+void copy_vector(void * vd, const void * vs)
+{
+#if defined(SSE2_SUPPORT)
+ /* MOVDQU  XMMWORD PTR[vd], XMMWORD PTR[vs] */
+    _mm_storeu_si128((__m128i *)vd, _mm_loadu_si128((__m128i *)vs));
+#elif defined(SSE1_SUPPORT)
+ /* MOVUPS  XMMWORD PTR[vd], XMMWORD PTR[vs] */
+    _mm_storeu_ps((float *)vd, _mm_loadu_ps((float *)vs));
+#elif 0
+ /* MOVDQA  XMMWORD PTR[vd], XMMWORD PTR[vs] */
+ /* MOVAPS  XMMWORD PTR[vd], XMMWORD PTR[vs] */
+    *(__m128 *)vd = *(__m128 *)vs; /* Crash if vd or vs not 128-bit aligned! */
+#else
+    memcpy(vd, vs, 8 * sizeof(i16));
+#endif
+}
+
 void swap_elements(i16 * RSP_vector)
 {
 #ifdef SSE2_SUPPORT

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -427,22 +427,22 @@ void copy_vector(void * vd, const void * vs)
 #endif
 }
 
-void swap_elements(i16 * RSP_vector)
+void swap_elements(void * vd, const void * vs)
 {
 #ifdef SSE2_SUPPORT
     __m128i RSP_as_XMM;
 
-    RSP_as_XMM = _mm_loadu_si128((__m128i *)RSP_vector);
+    RSP_as_XMM = _mm_loadu_si128((__m128i *)vs);
     RSP_as_XMM = _mm_shufflehi_epi16(RSP_as_XMM, _MM_SHUFFLE(2, 3, 0, 1));
     RSP_as_XMM = _mm_shufflelo_epi16(RSP_as_XMM, _MM_SHUFFLE(2, 3, 0, 1));
-    _mm_storeu_si128((__m128i *)RSP_vector, RSP_as_XMM);
+    _mm_storeu_si128((__m128i *)vd, RSP_as_XMM);
 #else
     i16 temp_vector[8];
     register size_t i;
 
     for (i = 0; i < 8; i++)
-        temp_vector[i] = RSP_vector[i ^ 1];
+        temp_vector[i] = vs[i ^ 1];
     for (i = 0; i < 8; i++)
-        RSP_vector[i] = temp_vector[i];
+        vd[i] = temp_vector[i];
 #endif
 }

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -215,4 +215,4 @@ extern void copy_vector(void * vd, const void * vs);
  * of that scenario until the memory layout is improved more permanently in
  * later changes.
  */
-extern void swap_elements(i16 * RSP_vector);
+extern void swap_elements(void * vd, const void * vs);

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -195,11 +195,15 @@ extern INLINE void vsatu64 (u16* vd, s32* vs);
 #endif
 
 /*
- * Unfortunately, as most of the low-level details of RSP hardware came from
- * the ultra-little-endian design from zilmar's RSP interpreter, much of RSP
- * vector simulation in this HLE revolved around backwards element order.
+ * Unfortunately, as much of the RSP analysis had to work around some early
+ * byte order tricks in zilmar's RSP interpreter, several cases of audio HLE
+ * will have extra endianness adjustments to them, sometimes redundantly.
  *
- * A quick fix to this is to have a function to switch the positions of
- * adjacent 16-bit RSP vector elements with each other.
+ * For example, reads and writes might frequently XOR each 16-bit address
+ * when moving to and from a location, to maintain little-endian vectors.
+ *
+ * This function will act as a temporary solution for optimizing away most
+ * of that scenario until the memory layout is improved more permanently in
+ * later changes.
  */
 extern void swap_elements(i16 * RSP_vector);

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -195,6 +195,15 @@ extern INLINE void vsatu64 (u16* vd, s32* vs);
 #endif
 
 /*
+ * There are two basic ways to copy an RSP vector to another RSP vector in
+ * emulated memory:  with alignment and without alignment.  Forcing 128-bit
+ * alignment requirements is a cycle or two faster on older CPUs, but on
+ * modern hardware there is no reason to force memory alignment constrictions
+ * or to use MOVDQA/MOVAPS and risk unaligned memory access seg. faults.
+ */
+extern void copy_vector(void * vd, const void * vs);
+
+/*
  * Unfortunately, as much of the RSP analysis had to work around some early
  * byte order tricks in zilmar's RSP interpreter, several cases of audio HLE
  * will have extra endianness adjustments to them, sometimes redundantly.


### PR DESCRIPTION
Before pushing these commits, I tested audio in _Super Mario 64_ and _Legend of Zelda:  Ocarina of Time_.  (Also made sure, I can break ADPCM on purpose and make audio sound like garbage, to make sure testing was set up right.)

Ultimately the purpose here is to change the 3 ADPCM loader function loops from:
```c
	for (u32 x = 0; x < ((k0 & 0xffff) >> 0x4); x++) {
		adpcmtable[0x1 + (x << 3)] = table[0];
		adpcmtable[0x0 + (x << 3)] = table[1];

		adpcmtable[0x3 + (x << 3)] = table[2];
		adpcmtable[0x2 + (x << 3)] = table[3];

		adpcmtable[0x5 + (x << 3)] = table[4];
		adpcmtable[0x4 + (x << 3)] = table[5];

		adpcmtable[0x7 + (x << 3)] = table[6];
		adpcmtable[0x6 + (x << 3)] = table[7];
		table += 8;
	}
```
... to ...
```c
	for (i = 0; i < limit; i++)
		swap_elements(&adpcmtable[8*i], &table[8*i]);
```
What does this mean on the low level?

Before it did this (MSVC 2013 generated asm):
```asm
$LL3@LOADADPCM:
	movzx   ecx, WORD PTR [eax]
	lea     eax, DWORD PTR [eax+16]
	mov     WORD PTR [edx+2], cx
	lea     edx, DWORD PTR [edx+16]
	movzx   ecx, WORD PTR [eax-14]
	mov     WORD PTR [edx-16], cx
	movzx   ecx, WORD PTR [eax-12]
	mov     WORD PTR [edx-10], cx
	movzx   ecx, WORD PTR [eax-10]
	mov     WORD PTR [edx-12], cx
	movzx   ecx, WORD PTR [eax-8]
	mov     WORD PTR [edx-6], cx
	movzx   ecx, WORD PTR [eax-6]
	mov     WORD PTR [edx-8], cx
	movzx   ecx, WORD PTR [eax-4]
	mov     WORD PTR [edx-2], cx
	movzx   ecx, WORD PTR [eax-2]
	mov     WORD PTR [edx-4], cx
	dec     esi
	jne     SHORT $LL3@LOADADPCM
```
Now it does this:
```asm
$LL3@LOADADPCM:
	lea     eax, DWORD PTR [eax+16]
	movdqu  xmm0, XMMWORD PTR [eax-16]
	pshufhw xmm0, xmm0, 177 ;# word-swap upper 64 bits
	pshuflw xmm0, xmm0, 177 ;# word-swap lower 64 bits
	movdqu  XMMWORD PTR [edx+eax-16], xmm0
	dec     ecx
	jne     SHORT $LL3@LOADADPCM
```