### PR TITLE
Update Visual Studio 2008 solution with some fixes/match downstream.

### DIFF
--- a/AziAudio.vs2008.sln
+++ b/AziAudio.vs2008.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 10.00
-# Visual C++ Express 2008
+# Visual Studio 2008
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AziAudio", "AziAudio\AziAudio.vcproj", "{835979AC-BC6A-45B7-A513-8EEE79B443DE}"
 EndProject
 Global

--- a/AziAudio/AziAudio.vcproj
+++ b/AziAudio/AziAudio.vcproj
@@ -40,7 +40,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;..\3rd Party\directx\include&quot;"
+				AdditionalIncludeDirectories="&quot;$(Root)3rd Party\directx\include&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;_USRDLL;AZIAUDIO_EXPORTS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -115,7 +115,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				AdditionalIncludeDirectories="&quot;..\3rd Party\directx\include&quot;"
+				AdditionalIncludeDirectories="&quot;$(Root)3rd Party\directx\include&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;_USRDLL;AZIAUDIO_EXPORTS"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"

--- a/AziAudio/AziAudio.vcproj
+++ b/AziAudio/AziAudio.vcproj
@@ -5,7 +5,6 @@
 	Name="AziAudio"
 	ProjectGUID="{835979AC-BC6A-45B7-A513-8EEE79B443DE}"
 	RootNamespace="AziAudio"
-	Keyword="Win32Proj"
 	TargetFrameworkVersion="196613"
 	>
 	<Platforms>


### PR DESCRIPTION
Frank74 found that the header note VS Express threw in was causing 2008 Professional to complain upon attempts at opening the solution -- https://github.com/Azimer/AziAudio/issues/29#issuecomment-101888939 -- so I changed it to use the standard VS2008 header which seems to work for both of us.

I also made a couple changes based on differences I spotted between project64/AziAudio and Azimer/AziAudio, but the solution file itself seems to now be basically identical to the one downstream that zilmar has going on, so at least that matches now.