### PR TITLE
Enable the negative shift amount assertion in ADPCM3.

### DIFF
--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -322,7 +322,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		book1 = (s16 *)&adpcmtable[index];
 		book2 = book1 + 8;
 		code >>= 4;									// upper nibble is scale
-#if 0
+#if 1
 		assert((12 - code) - 1 >= 0);
 #endif
 		vscale = 0x8000u >> ((12 - code) - 1);		// very strange. 0x8000 would be .5 in 16:16 format

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -322,14 +322,14 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		book1 = (s16 *)&adpcmtable[index];
 		book2 = book1 + 8;
 		code >>= 4;									// upper nibble is scale
-#if 1
-		assert((12 - code) - 1 >= 0);
-#endif
+
 		vscale = 0x8000u >> ((12 - code) - 1);		// very strange. 0x8000 would be .5 in 16:16 format
 		// so this appears to be a fractional scale based
 		// on the 12 based inverse of the scale value.  note
 		// that this could be negative, in which case we do
 		// not use the calculated vscale value...
+		if ((12 - code) - 1 < 0)
+			vscale = 0x10000; /* null operation:  << 16 then >> 16 */
 
 		inPtr++;									// coded adpcm data lies next
 		j = 0;


### PR DESCRIPTION
I felt like showing a commit for this, because the negative shift amount actually happens in DK64.

It was discussed earlier in this issue:  https://github.com/Azimer/AziAudio/issues/66

... that we should be able to change ...
```c
void InitInput(s32 *inp, int index, u8 icode, u8 mask, u8 shifter, u8 code, u8 srange, int vscale)
{
    inp[index] = (s16)((icode & mask) << shifter);
    if (code < srange)
        inp[index] = (inp[index] * vscale) >> 16;
    else
        int catchme = 1;
}
```
... to ...
```c
void InitInput(s32 *inp, int index, u8 icode, u8 mask, u8 shifter, int vscale)
{
    inp[index] = (s16)((icode & mask) << shifter);
    inp[index] = (inp[index] * vscale) >> 16;
}
```
However it turns out that removing the `if (code < srange)` check from the InitInput function broke ADPCM3 which you can hear by booting Donkey Kong.  I don't know what the intention is for cases where the shift amount could be negative, so I'm merely enabling the assert in this commit until @Azimer might have a closer look at that.