### PR TITLE
Compressed code in EnvMixer

### DIFF
--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -519,35 +519,18 @@ void ENVMIXER3() {
 		// ****************************************************************
 		MainL = MixVol(Dry, LVol);
 		MainR = MixVol(Dry, RVol);
-
 		i1 = inp[MES(y)];
 
-		o1 = out[MES(y)] + MixVol(i1, MainL);
-		a1 = aux1[MES(y)] + MixVol(i1, MainR);
-
-		// ****************************************************************
-
-		o1 = pack_signed(o1);
-		a1 = pack_signed(a1);
-
-		// ****************************************************************
-
-		out[MES(y)] = o1;
-		aux1[MES(y)] = a1;
+		out[MES(y)] = pack_signed(out[MES(y)] + MixVol(i1, MainL));
+		aux1[MES(y)] = pack_signed(aux1[MES(y)] + MixVol(i1, MainR));
 
 		// ****************************************************************
 		//if (!(flags&A_AUX)) {
 		AuxL = MixVol(Wet, LVol);
 		AuxR = MixVol(Wet, RVol);
 
-		a2 = aux2[MES(y)] + MixVol(i1, AuxL);
-		a3 = aux3[MES(y)] + MixVol(i1, AuxR);
-
-		a2 = pack_signed(a2);
-		a3 = pack_signed(a3);
-
-		aux2[MES(y)] = a2;
-		aux3[MES(y)] = a3;
+		aux2[MES(y)] = pack_signed(aux2[MES(y)] + MixVol(i1, AuxL));
+		aux3[MES(y)] = pack_signed(aux3[MES(y)] + MixVol(i1, AuxR));
 	}
 	//}
 

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -137,7 +137,7 @@ void ENVMIXER() {
 	s32 MainL;
 	s32 AuxR;
 	s32 AuxL;
-	s32 i1, o1, a1, a2, a3;
+	s32 i1;
 	WORD AuxIncRate = 1;
 	s16 zero[8];
 	memset(zero, 0, sizeof(s16) * 8);
@@ -211,12 +211,6 @@ void ENVMIXER() {
 
 		for (int x = 0; x < 8; x++) {
 			i1 = inp[MES(ptr)];
-			o1 = out[MES(ptr)];
-			a1 = aux1[MES(ptr)];
-			if (AuxIncRate) {
-				a2 = aux2[MES(ptr)];
-				a3 = aux3[MES(ptr)];
-			}
 			// TODO: here...
 			//LAcc = LTrg;
 			//RAcc = RTrg;
@@ -291,30 +285,17 @@ void ENVMIXER() {
 			AuxR  = (Wet * RTrg + 0x8000)  >> 16;
 			AuxL  = (Wet * LTrg + 0x8000)  >> 16;*/
 
-			o1 += MixVol(/*(o1*0x7fff)+*/ i1, MainR);
-			a1 += MixVol(/*(a1*0x7fff)+*/ i1, MainL);
-
 			/*		o1=((s64)(((s64)o1*0xfffe)+((s64)i1*MainR*2)+0x8000)>>16);
-
 			a1=((s64)(((s64)a1*0xfffe)+((s64)i1*MainL*2)+0x8000)>>16);*/
 
-			o1 = pack_signed(o1);
-			a1 = pack_signed(a1);
-
-			out[MES(ptr)] = o1;
-			aux1[MES(ptr)] = a1;
+			out[MES(ptr)] = pack_signed(out[MES(ptr)] + MixVol(/*(o1*0x7fff)+*/ i1, MainR));
+			aux1[MES(ptr)] = pack_signed(aux1[MES(ptr)] + MixVol(/*(a1*0x7fff)+*/ i1, MainL));
 			if (AuxIncRate) {
 				//a2=((s64)(((s64)a2*0xfffe)+((s64)i1*AuxR*2)+0x8000)>>16);
-
 				//a3=((s64)(((s64)a3*0xfffe)+((s64)i1*AuxL*2)+0x8000)>>16);
-				a2 += MixVol(/*(a2*0x7fff)+*/i1, AuxR);
-				a3 += MixVol(/*(a3*0x7fff)+*/i1, AuxL);
 
-				a2 = pack_signed(a2);
-				a3 = pack_signed(a3);
-
-				aux2[MES(ptr)] = a2;
-				aux3[MES(ptr)] = a3;
+				aux2[MES(ptr)] = pack_signed(aux2[MES(ptr)] + MixVol(/*(a2*0x7fff)+*/i1, AuxR));
+				aux3[MES(ptr)] = pack_signed(aux3[MES(ptr)] + MixVol(/*(a3*0x7fff)+*/i1, AuxL));
 			}
 			ptr++;
 		}

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -432,7 +432,7 @@ void ENVMIXER3() {
 	s32 MainL;
 	s32 AuxR;
 	s32 AuxL;
-	s32 i1, o1, a1, a2, a3;
+	s32 i1;
 	WORD AuxIncRate = 1;
 	s16 zero[8];
 	memset(zero, 0, sizeof(s16) * 8);

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -520,12 +520,10 @@ void ENVMIXER3() {
 		MainL = MixVol(Dry, LVol);
 		MainR = MixVol(Dry, RVol);
 
-		o1 = out[MES(y)];
-		a1 = aux1[MES(y)];
 		i1 = inp[MES(y)];
 
-		o1 += MixVol(i1, MainL);
-		a1 += MixVol(i1, MainR);
+		o1 = out[MES(y)] + MixVol(i1, MainL);
+		a1 = aux1[MES(y)] + MixVol(i1, MainR);
 
 		// ****************************************************************
 
@@ -539,14 +537,11 @@ void ENVMIXER3() {
 
 		// ****************************************************************
 		//if (!(flags&A_AUX)) {
-		a2 = aux2[MES(y)];
-		a3 = aux3[MES(y)];
-
 		AuxL = MixVol(Wet, LVol);
 		AuxR = MixVol(Wet, RVol);
 
-		a2 += MixVol(i1, AuxL);
-		a3 += MixVol(i1, AuxR);
+		a2 = aux2[MES(y)] + MixVol(i1, AuxL);
+		a3 = aux3[MES(y)] + MixVol(i1, AuxR);
 
 		a2 = pack_signed(a2);
 		a3 = pack_signed(a3);


### PR DESCRIPTION
I noticed that in the previous pull request #70, we made use of the pack_signed function to reduce a lot of clutter while still maintaining readability (i.e. we turned 3 lines of code into a single line by removing a <code>temp</code> variable)

In the main loop of EnvMixer3(), it is incrementing <code>out[MES(y)], aux1[MES(y)]</code>, etc. I was thinking that instead of having all those temporary variables like <code>o1</code> and <code>a1</code>, why not replace it with one line of addition using the pack_signed function? 