### PR TITLE
Change RomOpened to RomOpen

### DIFF
--- a/AziAudio/AudioSpec.h
+++ b/AziAudio/AudioSpec.h
@@ -197,7 +197,7 @@ EXPORT void CALL ProcessAList(void);
   output:   none
 *******************************************************************/ 
 EXPORT void CALL RomClosed(void);
-EXPORT void CALL RomOpened(void);
+EXPORT void CALL RomOpen(void);
 EXPORT void CALL PluginLoaded(void);
 
 EXPORT void CALL AiCallBack(void);

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -287,7 +287,7 @@ EXPORT void CALL ProcessAList(void) {
 	}
 }
 
-EXPORT void CALL RomOpened(void) {
+EXPORT void CALL RomOpen(void) {
 	ChangeABI(0);
 	snd.DeInitialize();
 	Dacrate = 0;


### PR DESCRIPTION
Due to the fact that Project64 2.x uses "RomOpen", the function
"RomOpened" is never used. Now RomOpen works. Hopefully this may help
with tracking down bugs :smile: .