### PR TITLE
optimized the main ADPCM buffer input operations

### DIFF
--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -113,7 +113,9 @@ void ADPCM() { // Work in progress! :)
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -122,7 +124,9 @@ void ADPCM() { // Work in progress! :)
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -230,7 +234,9 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -239,7 +245,9 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -323,7 +331,9 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)]; //*(out+i)=a[MES(i)];
 		//out += 0x10;
@@ -333,7 +343,9 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i] >> 11);
+			a[i] = a[i] >> 11;
+		for (int i = 0; i < 8; i++)
+			a[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
 

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -113,7 +113,7 @@ void ADPCM() { // Work in progress! :)
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -122,7 +122,7 @@ void ADPCM() { // Work in progress! :)
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -230,7 +230,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -239,7 +239,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
 
@@ -323,7 +323,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)]; //*(out+i)=a[MES(i)];
 		//out += 0x10;
@@ -333,7 +333,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
-			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+			a[i] = pack_signed(a[i] >> 11);
 		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
 

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -112,22 +112,20 @@ void ADPCM() { // Work in progress! :)
 		}
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
-		}
+
 		l1 = a[6];
 		l2 = a[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
-		}
+
 		l1 = a[6];
 		l2 = a[7];
 
@@ -231,22 +229,20 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		}
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
-		}
+
 		l1 = a[6];
 		l2 = a[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
+		for (int i = 0; i < 8; i++)
 			*(out++) = (s16)a[MES(i)];
-		}
+
 		l1 = a[6];
 		l2 = a[7];
 
@@ -326,25 +322,21 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		}
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
-			*(out++) = (s16)a[MES(i)];
-			//*(out+j)=a[MES(j)];
-		}
+		for (int i = 0; i < 8; i++)
+			*(out++) = (s16)a[MES(i)]; //*(out+i)=a[MES(i)];
 		//out += 0x10;
+
 		l1 = a[6];
 		l2 = a[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
-
 		for (int i = 0; i < 8; i++)
-		{
 			a[MES(i)] = pack_signed(a[MES(i)] >> 11);
-			*(out++) = (s16)a[MES(i)];
-			//*(out+i+0x1f8)=a[MES(i)];
-		}
+		for (int i = 0; i < 8; i++)
+			*(out++) = (s16)a[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
+
 		l1 = a[6];
 		l2 = a[7];
 

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -116,8 +116,8 @@ void ADPCM() { // Work in progress! :)
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		vsats128(&b[0], &a[0]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)];
+		swap_elements(out, &b[0]);
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];
@@ -126,8 +126,8 @@ void ADPCM() { // Work in progress! :)
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		vsats128(&b[0], &a[0]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)];
+		swap_elements(out, &b[0]);
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -239,8 +239,8 @@ void ADPCM2() { // Verified to be 100% Accurate...
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
 			b[i] = pack_signed(a[i]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)];
+		swap_elements(out, &b[0]);
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];
@@ -250,8 +250,8 @@ void ADPCM2() { // Verified to be 100% Accurate...
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
 			b[i] = pack_signed(a[i]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)];
+		swap_elements(out, &b[0]);
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];
@@ -337,9 +337,8 @@ void ADPCM3() { // Verified to be 100% Accurate...
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
 			b[i] = pack_signed(a[i]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)]; //*(out+i)=a[MES(i)];
-		//out += 0x10;
+		swap_elements(out, &b[0]);
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];
@@ -349,8 +348,8 @@ void ADPCM3() { // Verified to be 100% Accurate...
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
 			b[i] = pack_signed(a[i]);
-		for (int i = 0; i < 8; i++)
-			*(out++) = b[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
+		swap_elements(out, &b[0]); // *(out + i + 0x1F8) = b[i ^ 1];
+		out += 8;
 
 		l1 = b[6];
 		l2 = b[7];

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -115,8 +115,7 @@ void ADPCM() { // Work in progress! :)
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = b[MES(i)];
 
@@ -126,8 +125,7 @@ void ADPCM() { // Work in progress! :)
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		for (int i = 0; i < 8; i++)
 			*(out++) = b[MES(i)];
 
@@ -237,8 +235,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		swap_elements(out, &b[0]);
 		out += 8;
 
@@ -248,8 +245,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		swap_elements(out, &b[0]);
 		out += 8;
 
@@ -335,8 +331,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		ADPCMFillArray(a, book1, book2, l1, l2, inp1);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		swap_elements(out, &b[0]);
 		out += 8;
 
@@ -346,8 +341,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
-		for (int i = 0; i < 8; i++)
-			b[i] = pack_signed(a[i]);
+		vsats128(&b[0], &a[0]);
 		swap_elements(out, &b[0]); // *(out + i + 0x1F8) = b[i ^ 1];
 		out += 8;
 

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -45,6 +45,7 @@ void ADPCM() { // Work in progress! :)
 	int vscale;
 	WORD index;
 	s32 a[8];
+	s16 b[8];
 	s16* book1;
 	s16* book2;
 
@@ -115,23 +116,23 @@ void ADPCM() { // Work in progress! :)
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)];
+			*(out++) = b[MES(i)];
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)];
+			*(out++) = b[MES(i)];
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		count -= 32;
 	}
@@ -151,6 +152,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 	int vscale;
 	WORD index;
 	s32 a[8];
+	s16 b[8];
 	s16* book1;
 	s16* book2;
 
@@ -236,23 +238,23 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)];
+			*(out++) = b[MES(i)];
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)];
+			*(out++) = b[MES(i)];
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		count -= 32;
 	}
@@ -272,6 +274,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 	int vscale;
 	WORD index;
 	s32 a[8];
+	s16 b[8];
 	s16* book1;
 	s16* book2;
 
@@ -333,24 +336,24 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)]; //*(out+i)=a[MES(i)];
+			*(out++) = b[MES(i)]; //*(out+i)=a[MES(i)];
 		//out += 0x10;
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		ADPCMFillArray(a, book1, book2, l1, l2, inp2);
 		for (int i = 0; i < 8; i++)
 			a[i] = a[i] >> 11;
 		for (int i = 0; i < 8; i++)
-			a[i] = pack_signed(a[i]);
+			b[i] = pack_signed(a[i]);
 		for (int i = 0; i < 8; i++)
-			*(out++) = (s16)a[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
+			*(out++) = b[MES(i)]; //*(out+i+0x1f8)=a[MES(i)];
 
-		l1 = a[6];
-		l2 = a[7];
+		l1 = b[6];
+		l2 = b[7];
 
 		count -= 32;
 	}


### PR DESCRIPTION
This should be much better for performance as well as smaller functions sizes...pretty sure I lost 1 KB off the DLL size.  I tested every commit with Zelda64 and Mario at the end but didn't really think to test for regressions beyond that since I operated on the assumption that this stuff was common to all games.  (Not to mention I did in fact find regressions already and fix them before making each next commit.)

The only `for` loop left after this change now is this:
```c
		for (int i = 0; i < 8; i++)
			a[i] = a[i] >> 11;
```
Nothing necessitates rewriting that to SSE because auto-vectorization is incredibly simple.  There's no excuse why an optimizing Intel compiler shouldn't compile that as a PSRAD xmm0, 11 or whatever.