### PR TITLE
Compress resample

### DIFF
--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -109,7 +109,7 @@ void RESAMPLE() {
 
 		// imul 
 
-		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -157,7 +157,7 @@ void RESAMPLE2() {
 		//location = (Accum >> 0xa) << 0x3;
 		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
-		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -226,7 +226,7 @@ void RESAMPLE3() {
 		}
 		*/
 
-		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -46,8 +46,9 @@ u16 ResampleLUT[0x200] = {
 	0xFFD8, 0x0E5F, 0x6696, 0x0B39, 0xFFDF, 0x0D46, 0x66AD, 0x0C39
 };
 
-s32 IncrAccum(s16 *src, u32 srcPtr, s16 *lut)
+s32 IncrAccum(s16 *src, u32 srcPtr, DWORD location)
 {
+	s16 *lut = (s16 *)(((u8 *)ResampleLUT) + location);
 	s32 accum = 0;
 	for (int i = 0; i < 4; i++)
 	{
@@ -64,7 +65,6 @@ void RESAMPLE() {
 	u32 addy = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 	DWORD Accum = 0;
 	DWORD location;
-	s16 *lut;
 	s16 *dst;
 	s16 *src;
 	dst = (s16 *)(BufferSpace);
@@ -94,7 +94,6 @@ void RESAMPLE() {
 	for (int i = 0; i < ((AudioCount + 0xf) & 0xFFF0) / 2; i++)	{
 		//location = (((Accum * 0x40) >> 0x10) * 8);
 		location = (Accum >> 0xa) << 0x3;
-		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
 		// mov eax, dword ptr [src+srcPtr];
 		// movsx edx, word ptr [lut];
@@ -109,7 +108,7 @@ void RESAMPLE() {
 
 		// imul 
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -127,7 +126,6 @@ void RESAMPLE2() {
 	u32 addy = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
 	DWORD Accum = 0;
 	DWORD location;
-	s16 *lut;
 	s16 *dst;
 	s16 *src;
 	dst = (s16 *)(BufferSpace);
@@ -155,9 +153,8 @@ void RESAMPLE2() {
 	for (int i = 0; i < ((AudioCount + 0xf) & 0xFFF0) / 2; i++)	{
 		location = (((Accum * 0x40) >> 0x10) * 8);
 		//location = (Accum >> 0xa) << 0x3;
-		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -175,7 +172,6 @@ void RESAMPLE3() {
 	u32 addy = (k0 & 0xffffff);
 	DWORD Accum = 0;
 	DWORD location;
-	s16 *lut;
 	s16 *dst;
 	s16 *src;
 	dst = (s16 *)(BufferSpace);
@@ -212,7 +208,6 @@ void RESAMPLE3() {
 	for (int i = 0; i < 0x170 / 2; i++)	{
 		location = (((Accum * 0x40) >> 0x10) * 8);
 		//location = (Accum >> 0xa) << 0x3;
-		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
 		/*
 		for (int i = 0; i < 4; i++)
@@ -226,7 +221,7 @@ void RESAMPLE3() {
 		}
 		*/
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, lut));
+		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -223,33 +223,16 @@ void RESAMPLE3() {
 
 		accum = IncrAccum(src, srcPtr, lut);
 		/*
-		temp =  ((s64)*(s16*)(src + MES(srcPtr+0))*((s64)((s16)lut[0]<<1)));
-		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
-		else temp = (temp^0x8000);
-		temp = (s32)(temp >> 16);
-		temp = pack_signed((s32)temp);
-		accum = (s32)(s16)temp;
-
-		temp = ((s64)*(s16*)(src + MES(srcPtr+1))*((s64)((s16)lut[1]<<1)));
-		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
-		else temp = (temp^0x8000);
-		temp = (s32)(temp >> 16);
-		temp = pack_signed((s32)temp);
-		accum += (s32)(s16)temp;
-
-		temp = ((s64)*(s16*)(src + MES(srcPtr+2))*((s64)((s16)lut[2]<<1)));
-		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
-		else temp = (temp^0x8000);
-		temp = (s32)(temp >> 16);
-		temp = pack_signed((s32)temp);
-		accum += (s32)(s16)temp;
-
-		temp = ((s64)*(s16*)(src + MES(srcPtr+3))*((s64)((s16)lut[3]<<1)));
-		if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
-		else temp = (temp^0x8000);
-		temp = (s32)(temp >> 16);
-		temp = pack_signed((s32)temp);
-		accum += (s32)(s16)temp;*/
+		for (int i = 0; i < 4; i++)
+		{
+			temp =  ((s64)*(s16*)(src + MES(srcPtr+i))*((s64)((s16)lut[i]<<1)));
+			if (temp & 0x8000) temp = (temp^0x8000) + 0x10000;
+			else temp = (temp^0x8000);
+			temp = (s32)(temp >> 16);
+			temp = pack_signed((s32)temp);
+			accum = (s32)(s16)temp;
+		}
+		*/
 
 		accum = pack_signed(accum);
 

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -46,7 +46,7 @@ u16 ResampleLUT[0x200] = {
 	0xFFD8, 0x0E5F, 0x6696, 0x0B39, 0xFFDF, 0x0D46, 0x66AD, 0x0C39
 };
 
-s32 IncrAccum(s16 *src, u32 srcPtr, DWORD location)
+s32 MultAddLUT(s16 *src, u32 srcPtr, DWORD location)
 {
 	s16 *lut = (s16 *)(((u8 *)ResampleLUT) + location);
 	s32 accum = 0;
@@ -108,7 +108,7 @@ void RESAMPLE() {
 
 		// imul 
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
+		dst[MES(dstPtr)] = pack_signed(MultAddLUT(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -154,7 +154,7 @@ void RESAMPLE2() {
 		location = (((Accum * 0x40) >> 0x10) * 8);
 		//location = (Accum >> 0xa) << 0x3;
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
+		dst[MES(dstPtr)] = pack_signed(MultAddLUT(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -221,7 +221,7 @@ void RESAMPLE3() {
 		}
 		*/
 
-		dst[MES(dstPtr)] = pack_signed(IncrAccum(src, srcPtr, location));
+		dst[MES(dstPtr)] = pack_signed(MultAddLUT(src, srcPtr, location));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -71,7 +71,7 @@ void RESAMPLE() {
 	src = (s16 *)(BufferSpace);
 	u32 srcPtr = (AudioInBuffer / 2);
 	u32 dstPtr = (AudioOutBuffer / 2);
-	s32 accum;
+
 	/*
 	if (addy > (1024*1024*8))
 	addy = (t9 & 0xffffff);
@@ -108,10 +108,8 @@ void RESAMPLE() {
 		// and edx, 0f000h
 
 		// imul 
-		accum = IncrAccum(src, srcPtr, lut);
-		accum = pack_signed(accum);
 
-		dst[MES(dstPtr)] = (s16)(accum);
+		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -136,7 +134,6 @@ void RESAMPLE2() {
 	src = (s16 *)(BufferSpace);
 	u32 srcPtr = (AudioInBuffer / 2);
 	u32 dstPtr = (AudioOutBuffer / 2);
-	s32 accum;
 
 	if (addy > (1024 * 1024 * 8))
 		addy = (t9 & 0xffffff);
@@ -160,10 +157,7 @@ void RESAMPLE2() {
 		//location = (Accum >> 0xa) << 0x3;
 		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
-		accum = IncrAccum(src, srcPtr, lut);
-		accum = pack_signed(accum);
-
-		dst[MES(dstPtr)] = (s16)(accum);
+		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);
@@ -188,7 +182,6 @@ void RESAMPLE3() {
 	src = (s16 *)(BufferSpace);
 	u32 srcPtr = ((((t9 >> 2) & 0xfff) + 0x4f0) / 2);
 	u32 dstPtr;//=(AudioOutBuffer/2);
-	s32 accum;
 
 	//if (addy > (1024*1024*8))
 	//	addy = (t9 & 0xffffff);
@@ -221,7 +214,6 @@ void RESAMPLE3() {
 		//location = (Accum >> 0xa) << 0x3;
 		lut = (s16 *)(((u8 *)ResampleLUT) + location);
 
-		accum = IncrAccum(src, srcPtr, lut);
 		/*
 		for (int i = 0; i < 4; i++)
 		{
@@ -234,9 +226,7 @@ void RESAMPLE3() {
 		}
 		*/
 
-		accum = pack_signed(accum);
-
-		dst[MES(dstPtr)] = (s16)(accum);
+		dst[MES(dstPtr)] = (s16)(pack_signed(IncrAccum(src, srcPtr, lut)));
 		dstPtr++;
 		Accum += Pitch;
 		srcPtr += (Accum >> 16);


### PR DESCRIPTION
Resample hasn't been touched much, so now is a good time to make changes. I applied the pack_signed function as well as a few other small changes. 

Note that most of the calculations take place in <code>MultAddLUT</code>, formerly called IncrAccum. I had to change the function name for IncrAccum because it was potentially misleading, given that there were two variables <code>accum</code> and <code>Accum</code> (just a small difference involving lowercase and uppercase). <code>accum</code> is more of a temp variable, but it has nothing to do with <code>Accum</code>. I renamed it to <code>MultAddLUT</code> since the function was doing multiplication and addition, but feel free to change it to a more appropriate name if needed.