### PR TITLE
Fix POLEF background noise agitation.

### DIFF
--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -172,8 +172,8 @@ void POLEF()
 	}
 	else {
 		memcpy((u8 *)hleMixerWorkArea, (rdram + Address), 8);
-		l1 = *(s16 *)(hleMixerWorkArea + 4);
-		l2 = *(s16 *)(hleMixerWorkArea + 6);
+		l1 = hleMixerWorkArea[2];
+		l2 = hleMixerWorkArea[3];
 	}
 
 	for (i = 0; i < 8; ++i) {
@@ -203,8 +203,8 @@ void POLEF()
 		count -= 16;
 	} while (count != 0);
 
-	*(s16 *)(hleMixerWorkArea + 4) = l1;
-	*(s16 *)(hleMixerWorkArea + 6) = l2;
+	hleMixerWorkArea[2] = l1;
+	hleMixerWorkArea[3] = l2;
 	memcpy((rdram + Address), (u8 *)hleMixerWorkArea, 8);
 }
 


### PR DESCRIPTION
This fixes the irritation in the background of the audio for games like _GoldenEye 007_.
It seems to have been caused by unhealthy practices of non-char pointer aliasing.

This does not include a fix for the remaining, quieter and harder to notice, fuzzy sound in the background.  To fix that as well, change:
```c
		for (i = 0; i < 8; ++i)
			frame[i] = inp[i];
```
to
```c
		for (i = 0; i < 8; ++i)
			frame[i] = inp[i ^ 1];
```
... which was what Azimer was going to do but said he wouldn't commit yet since the fix didn't have any noticeable effect.  I think the effect will be more noticeable after the louder, more noticeable issue fixed with this commit is done.

I didn't include a commit to fix it to inp[i ^ 1] in this pull request either because that will create a conflict with the other pull request I have open...I can just change it from copy_vector to swap_elements to fix that issue on my end, or Azimer can commit it to inp[i ^ 1] himself and I can resolve merge conflicts.