### PR TITLE
Let compiler decide whether to in-line procs with external linkage.

### DIFF
--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -345,7 +345,7 @@ u16 pack_unsigned(s32 slice)
     return (u16)(result & 0x0000FFFFul);
 }
 
-INLINE void vsats128(s16* vd, s32* vs)
+void vsats128(s16* vd, s32* vs)
 {
 #ifdef SSE2_SUPPORT
     __m128i result, xmm_hi, xmm_lo;
@@ -361,14 +361,14 @@ INLINE void vsats128(s16* vd, s32* vs)
         vd[i] = pack_signed(vs[i]);
 #endif
 }
-INLINE void vsatu128(u16* vd, s32* vs)
+void vsatu128(u16* vd, s32* vs)
 {
     register size_t i;
 
     for (i = 0; i < 8; i++)
         vd[i] = pack_unsigned(vs[i]);
 }
-INLINE void vsats64 (s16* vd, s32* vs)
+void vsats64 (s16* vd, s32* vs)
 {
 #if defined (_M_X64)
     __m128i xmm;
@@ -391,7 +391,7 @@ INLINE void vsats64 (s16* vd, s32* vs)
         vd[i] = pack_signed(vs[i]);
 #endif
 }
-INLINE void vsatu64 (u16* vd, s32* vs)
+void vsatu64 (u16* vd, s32* vs)
 {
     register size_t i;
 

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -176,10 +176,10 @@ vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); }
 #define vsatu64(vd, vs) {       \
 vd[0] = pack_unsigned(vs[0]); vd[1] = pack_unsigned(vs[1]); }
 #else
-extern INLINE void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
-extern INLINE void vsatu128(u16* vd, s32* vs);
-extern INLINE void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
-extern INLINE void vsatu64 (u16* vd, s32* vs);
+extern void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
+extern void vsatu128(u16* vd, s32* vs);
+extern void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
+extern void vsatu64 (u16* vd, s32* vs);
 #endif
 
 /*


### PR DESCRIPTION
This worked on MSVC but not necessarily in other cases, so the INLINE hint is temporarily off limits with externally linked symbols.

From what I have seen MSVC will still automatically select these functions for in-line expansion anyway.