### PR TITLE
Initialize data in a loop

### DIFF
--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -283,25 +283,12 @@ void InnerLoop () {
 	// Part 1: 100% Accurate
 	int i;
 
-	v[ 0] = GetData(0x00); v[31] = GetData(0x3E); v[ 0] += v[31];
-	v[ 1] = GetData(0x02); v[30] = GetData(0x3C); v[ 1] += v[30];
-	v[ 2] = GetData(0x06); v[28] = GetData(0x38); v[ 2] += v[28];
-	v[ 3] = GetData(0x04); v[29] = GetData(0x3A); v[ 3] += v[29];
-
-	v[ 4] = GetData(0x0E); v[24] = GetData(0x30); v[ 4] += v[24];
-	v[ 5] = GetData(0x0C); v[25] = GetData(0x32); v[ 5] += v[25];
-	v[ 6] = GetData(0x08); v[27] = GetData(0x36); v[ 6] += v[27];
-	v[ 7] = GetData(0x0A); v[26] = GetData(0x34); v[ 7] += v[26];
-
-	v[ 8] = GetData(0x1E); v[16] = GetData(0x20); v[ 8] += v[16];
-	v[ 9] = GetData(0x1C); v[17] = GetData(0x22); v[ 9] += v[17];
-	v[10] = GetData(0x18); v[19] = GetData(0x26); v[10] += v[19];
-	v[11] = GetData(0x1A); v[18] = GetData(0x24); v[11] += v[18];
-
-	v[12] = GetData(0x10); v[23] = GetData(0x2E); v[12] += v[23];
-	v[13] = GetData(0x12); v[22] = GetData(0x2C); v[13] += v[22];
-	v[14] = GetData(0x16); v[20] = GetData(0x28); v[14] += v[20];
-	v[15] = GetData(0x14); v[21] = GetData(0x2A); v[15] += v[21];
+	for (i = 0; i < 16; i++)
+		v[i] = GetData(2 * (i ^ (i / 2) ^ (i / 4) ^ (i / 8)));
+	for (i = 16; i < 32; i++)
+		v[i] = GetData(2 * i);
+	for (i = 0; i < 16; i++)
+		v[i] += v[(32 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
 
 	// Part 2-4
 	MP3AB0 ();
@@ -385,25 +372,12 @@ void InnerLoop () {
 	// 0x14FC - Verified...
 
 	// Part 6 - 100% Accurate
-	v[ 0] = GetData(0x00); v[31] = GetData(0x3E); v[ 0] -= v[31];
-	v[ 1] = GetData(0x02); v[30] = GetData(0x3C); v[ 1] -= v[30];
-	v[ 2] = GetData(0x06); v[28] = GetData(0x38); v[ 2] -= v[28];
-	v[ 3] = GetData(0x04); v[29] = GetData(0x3A); v[ 3] -= v[29];
-
-	v[ 4] = GetData(0x0E); v[24] = GetData(0x30); v[ 4] -= v[24];
-	v[ 5] = GetData(0x0C); v[25] = GetData(0x32); v[ 5] -= v[25];
-	v[ 6] = GetData(0x08); v[27] = GetData(0x36); v[ 6] -= v[27];
-	v[ 7] = GetData(0x0A); v[26] = GetData(0x34); v[ 7] -= v[26];
-
-	v[ 8] = GetData(0x1E); v[16] = GetData(0x20); v[ 8] -= v[16];
-	v[ 9] = GetData(0x1C); v[17] = GetData(0x22); v[ 9] -= v[17];
-	v[10] = GetData(0x18); v[19] = GetData(0x26); v[10] -= v[19];
-	v[11] = GetData(0x1A); v[18] = GetData(0x24); v[11] -= v[18];
-
-	v[12] = GetData(0x10); v[23] = GetData(0x2E); v[12] -= v[23];
-	v[13] = GetData(0x12); v[22] = GetData(0x2C); v[13] -= v[22];
-	v[14] = GetData(0x16); v[20] = GetData(0x28); v[14] -= v[20];
-	v[15] = GetData(0x14); v[21] = GetData(0x2A); v[15] -= v[21];
+	for (i = 0; i < 16; i++)
+		v[i] = GetData(2 * (i ^ (i / 2) ^ (i / 4) ^ (i / 8)));
+	for (i = 16; i < 32; i++)
+		v[i] = GetData(2 * i);
+	for (i = 0; i < 16; i++)
+		v[i] -= v[(32 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
 
 	//0, 1, 3, 2, 7, 6, 4, 5, 7, 6, 4, 5, 0, 1, 3, 2
 	const u16 LUT6[16] = {

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -288,7 +288,7 @@ void InnerLoop () {
 	for (i = 16; i < 32; i++)
 		v[i] = GetData(2 * i);
 	for (i = 0; i < 16; i++)
-		v[i] += v[(32 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
+		v[i] += v[(31 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
 
 	// Part 2-4
 	MP3AB0 ();
@@ -377,7 +377,7 @@ void InnerLoop () {
 	for (i = 16; i < 32; i++)
 		v[i] = GetData(2 * i);
 	for (i = 0; i < 16; i++)
-		v[i] -= v[(32 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
+		v[i] -= v[(31 - i) ^ (i / 2) ^ (i / 4) ^ (i / 8)];
 
 	//0, 1, 3, 2, 7, 6, 4, 5, 7, 6, 4, 5, 0, 1, 3, 2
 	const u16 LUT6[16] = {


### PR DESCRIPTION
Few observations:
v[0]...v[15] gets data from the array mp3data via multiple xor operations (to be exact, it's 
in the form `v[i] = GetData(2 * (i ^ (i / 2) ^ (i / 4) ^ (i / 8)))`. 
v[16]....v[31] gets data in the form `v[i] = GetData(2 * i).

The way the values are set up, there is a lot of swapping among a pair of elements. I wrote out all the values and expanded

Just for a concrete example...
`v[0] = GetData(2 * (0 ^ 0 ^ 0 ^ 0)) = GetData(0x00)`
`v[1] = GetData(2 * (1 ^ 0 ^ 0 ^ 0)) = GetData(2 * 1) = GetData(0x02)`
`v[2] = GetData(2 * (2 ^ 1 ^ 0 ^ 0)) = GetData(2 * 3) = GetData(0x06)`
`v[3] = GetData(2 * (3 ^ 1 ^ 0 ^ 0)) = GetData(2 * 2) = GetData(0x04)`
etc...

I don't think there's any errors, but you could double check to make sure all the indicies are correct.

