### PR TITLE
Replace CPU-RSP memory macros with pointer names.

### DIFF
--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -251,11 +251,11 @@ void MP3 () {
 
 	writePtr = t9 & 0xFFFFFF;
 	readPtr  = writePtr;
-	memcpy (mp3data+0xCE8, rdram+readPtr, 8); // Just do that for efficiency... may remove and use directly later anyway
+	memcpy (mp3data+0xCE8, DRAM + readPtr, 8); // Just do that for efficiency... may remove and use directly later anyway
 	readPtr += 8; // This must be a header byte or whatnot
 
 	for (int cnt = 0; cnt < 0x480; cnt += 0x180) {
-		memcpy (mp3data+0xCF0, rdram+readPtr, 0x180); // DMA: 0xCF0 <- RDRAM[s5] : 0x180
+		memcpy (mp3data+0xCF0, DRAM + readPtr, 0x180); // DMA: 0xCF0 <- RDRAM[s5] : 0x180
 		inPtr  = 0xCF0; // s7
 		outPtr = 0xE70; // s3
 // --------------- Inner Loop Start --------------------
@@ -273,7 +273,7 @@ void MP3 () {
 			inPtr += 0x40;
 		}
 // --------------- Inner Loop End --------------------
-		memcpy (rdram+writePtr, mp3data+0xe70, 0x180);
+		memcpy(DRAM + writePtr, mp3data+0xe70, 0x180);
 		writePtr += 0x180;
 		readPtr  += 0x180;
 	}

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -199,10 +199,10 @@ void ADPCM() { // Work in progress! :)
 	if (!(Flags & 0x1))
 	{
 		if (Flags & 0x2) {
-			memcpy(out, &rdram[loopval], 32);
+			memcpy(out, &DRAM[loopval], 32);
 		}
 		else {
-			memcpy(out, &rdram[Address], 32);
+			memcpy(out, &DRAM[Address], 32);
 		}
 	}
 
@@ -276,7 +276,7 @@ void ADPCM() { // Work in progress! :)
 		count -= 32;
 	}
 	out -= 16;
-	memcpy(&rdram[Address], out, 32);
+	memcpy(&DRAM[Address], out, 32);
 }
 
 void ADPCM2() { // Verified to be 100% Accurate...
@@ -305,9 +305,9 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 	if (!(Flags & 0x1))
 		if (Flags & 0x2)
-			memcpy(out, &rdram[loopval], 32);
+			memcpy(out, &DRAM[loopval], 32);
 		else
-			memcpy(out, &rdram[Address], 32);
+			memcpy(out, &DRAM[Address], 32);
 	if (Flags & 0x4) { // Tricky lil Zelda MM and ABI2!!! hahaha I know your secrets! :DDD
 		srange = 0xE;
 		inpinc = 0x5;
@@ -396,7 +396,7 @@ void ADPCM2() { // Verified to be 100% Accurate...
 		count -= 32;
 	}
 	out -= 16;
-	memcpy(&rdram[Address], out, 32);
+	memcpy(&DRAM[Address], out, 32);
 }
 
 void ADPCM3() { // Verified to be 100% Accurate...
@@ -419,9 +419,9 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 	if (!(Flags & 0x1))
 		if (Flags & 0x2)
-			memcpy(out, &rdram[loopval], 32);
+			memcpy(out, &DRAM[loopval], 32);
 		else
-			memcpy(out, &rdram[Address], 32);
+			memcpy(out, &DRAM[Address], 32);
 
 	s16 l1 = out[15];
 	s16 l2 = out[14];
@@ -492,7 +492,7 @@ void ADPCM3() { // Verified to be 100% Accurate...
 		count -= 32;
 	}
 	out -= 16;
-	memcpy(&rdram[Address], out, 32);
+	memcpy(&DRAM[Address], out, 32);
 }
 
 void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
@@ -504,7 +504,7 @@ void LOADADPCM() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	//		v0 = (t9 & 0xffffff);
 	//	memcpy (dmem+0x4c0, rdram+v0, k0&0xffff); // Could prolly get away with not putting this in dmem
 	//	assert ((k0&0xffff) <= 0x80);
-	u16 *table = (u16 *)(rdram + v0);
+	u16 *table = (u16 *)(DRAM + v0);
 
 	limit = (k0 & 0x0000FFFF) >> 4;
 	for (i = 0; i < limit; i++)
@@ -516,7 +516,7 @@ void LOADADPCM2() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	size_t i, limit;
 
 	v0 = (t9 & 0xffffff);// + SEGMENTS[(t9>>24)&0xf];
-	u16 *table = (u16 *)(rdram + v0); // Zelda2 Specific...
+	u16 *table = (u16 *)(DRAM + v0); // Zelda2 Specific...
 
 	limit = (k0 & 0x0000FFFF) >> 4;
 	for (i = 0; i < limit; i++)
@@ -530,7 +530,7 @@ void LOADADPCM3() { // Loads an ADPCM table - Works 100% Now 03-13-01
 	v0 = (t9 & 0xffffff);
 	//memcpy (dmem+0x3f0, rdram+v0, k0&0xffff);
 	//assert ((k0&0xffff) <= 0x80);
-	u16 *table = (u16 *)(rdram + v0);
+	u16 *table = (u16 *)(DRAM + v0);
 
 	limit = (k0 & 0x0000FFFF) >> 4;
 	for (i = 0; i < limit; i++)

--- a/AziAudio/ABI_Buffers.cpp
+++ b/AziAudio/ABI_Buffers.cpp
@@ -100,14 +100,14 @@ void LOADBUFF() { // memcpy causes static... endianess issue :(
 	if (AudioCount == 0)
 		return;
 	v0 = (t9 & 0xfffffc);// + SEGMENTS[(t9>>24)&0xf];
-	memcpy(BufferSpace + (AudioInBuffer & 0xFFFC), rdram + v0, (AudioCount + 3) & 0xFFFC);
+	memcpy(BufferSpace + (AudioInBuffer & 0xFFFC), DRAM + v0, (AudioCount + 3) & 0xFFFC);
 }
 
 void LOADBUFF2() { // Needs accuracy verification...
 	u32 v0;
 	u32 cnt = (((k0 >> 0xC) + 3) & 0xFFC);
 	v0 = (t9 & 0xfffffc);// + SEGMENTS[(t9>>24)&0xf];
-	memcpy(BufferSpace + (k0 & 0xfffc), rdram + v0, (cnt + 3) & 0xFFFC);
+	memcpy(BufferSpace + (k0 & 0xfffc), DRAM + v0, (cnt + 3) & 0xFFFC);
 }
 
 void LOADBUFF3() {
@@ -115,7 +115,7 @@ void LOADBUFF3() {
 	u32 cnt = (((k0 >> 0xC) + 3) & 0xFFC);
 	v0 = (t9 & 0xfffffc);
 	u32 src = (k0 & 0xffc) + 0x4f0;
-	memcpy(BufferSpace + src, rdram + v0, cnt);
+	memcpy(BufferSpace + src, DRAM + v0, cnt);
 }
 
 // TODO: This comment has me wondering if there's a problem.  10+ year old comments are hard to remember. -Azimer
@@ -124,14 +124,14 @@ void SAVEBUFF() { // memcpy causes static... endianess issue :(
 	if (AudioCount == 0)
 		return;
 	v0 = (t9 & 0xfffffc);// + SEGMENTS[(t9>>24)&0xf];
-	memcpy(rdram + v0, BufferSpace + (AudioOutBuffer & 0xFFFC), (AudioCount + 3) & 0xFFFC);
+	memcpy(DRAM + v0, BufferSpace + (AudioOutBuffer & 0xFFFC), (AudioCount + 3) & 0xFFFC);
 }
 
 void SAVEBUFF2() { // Needs accuracy verification...
 	u32 v0;
 	u32 cnt = (((k0 >> 0xC) + 3) & 0xFFC);
 	v0 = (t9 & 0xfffffc);// + SEGMENTS[(t9>>24)&0xf];
-	memcpy(rdram + v0, BufferSpace + (k0 & 0xfffc), (cnt + 3) & 0xFFFC);
+	memcpy(DRAM + v0, BufferSpace + (k0 & 0xfffc), (cnt + 3) & 0xFFFC);
 }
 
 void SAVEBUFF3() {
@@ -139,7 +139,7 @@ void SAVEBUFF3() {
 	u32 cnt = (((k0 >> 0xC) + 3) & 0xFFC);
 	v0 = (t9 & 0xfffffc);
 	u32 src = (k0 & 0xffc) + 0x4f0;
-	memcpy(rdram + v0, BufferSpace + src, cnt);
+	memcpy(DRAM + v0, BufferSpace + src, cnt);
 }
 
 void SEGMENT() { // Should work

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -170,7 +170,7 @@ void ENVMIXER() {
 	else {
 		// Load LVol, RVol, LAcc, and RAcc (all 32bit)
 		// Load Wet, Dry, LTrg, RTrg
-		memcpy((u8 *)hleMixerWorkArea, (rdram + addy), 80);
+		memcpy((u8 *)hleMixerWorkArea, DRAM + addy, 80);
 		Wet = LoadMixer16(0); // 0-1
 		Dry = LoadMixer16(2); // 2-3
 		LTrg = LoadMixer32(4); // 4-5
@@ -316,7 +316,7 @@ void ENVMIXER() {
 	SaveMixer32(14, RAdderEnd); // 14-15
 	SaveMixer32(16, LAdderStart); // 12-13
 	SaveMixer32(18, RAdderStart); // 14-15
-	memcpy(rdram + addy, (u8 *)hleMixerWorkArea, 80);
+	memcpy(DRAM + addy, (u8 *)hleMixerWorkArea, 80);
 }
 
 void ENVMIXER_GE() {
@@ -356,7 +356,7 @@ void ENVMIXER_GE() {
 		LTrg = VolTrg_Left; RTrg = VolTrg_Right; // Save Current Left/Right Targets
 	}
 	else {
-		memcpy((u8 *)hleMixerWorkArea, rdram + addy, 80);
+		memcpy((u8 *)hleMixerWorkArea, DRAM + addy, 80);
 		Wet = LoadMixer16(0); // 0-1
 		Dry = LoadMixer16(2); // 2-3
 		LTrg = LoadMixer16(4); // 4-5
@@ -443,7 +443,7 @@ void ENVMIXER_GE() {
 	SaveMixer32(18, RVol); // 18-19
 	SaveMixer16(20, LSig); // 20-21
 	SaveMixer16(22, RSig); // 22-23
-	memcpy(rdram + addy, (u8 *)hleMixerWorkArea, 80);
+	memcpy(DRAM + addy, (u8 *)hleMixerWorkArea, 80);
 }
 
 void ENVMIXER2() {
@@ -570,7 +570,7 @@ void ENVMIXER3() {
 		LTrg = VolTrg_Left; RTrg = VolTrg_Right; // Save Current Left/Right Targets
 	}
 	else {
-		memcpy((u8 *)hleMixerWorkArea, rdram + addy, 80);
+		memcpy((u8 *)hleMixerWorkArea, DRAM + addy, 80);
 		Wet = LoadMixer16(0); // 0-1
 		Dry = LoadMixer16(2); // 2-3
 		LTrg = LoadMixer16(4); // 4-5
@@ -657,7 +657,7 @@ void ENVMIXER3() {
 	SaveMixer16(20, LSig); // 20-21
 	SaveMixer16(22, RSig); // 22-23
 	//*(u32 *)(hleMixerWorkArea + 24) = 0x13371337; // 22-23
-	memcpy(rdram + addy, (u8 *)hleMixerWorkArea, 80);
+	memcpy(DRAM + addy, (u8 *)hleMixerWorkArea, 80);
 }
 
 void SETVOL() {

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -83,7 +83,7 @@ void FILTER2() {
 	static int cnt = 0;
 	static s16 *lutt6;
 	static s16 *lutt5;
-	u8 *save = (rdram + (t9 & 0xFFFFFF));
+	u8 *save = DRAM + (t9 & 0xFFFFFF);
 	u8 t4 = (u8)((k0 >> 0x10) & 0xFF);
 
 	if (t4 > 1) { // Then set the cnt variable
@@ -196,7 +196,7 @@ void POLEF()
 		l2 = 0;
 	}
 	else {
-		memcpy((u8 *)hleMixerWorkArea, (rdram + Address), 8);
+		memcpy(hleMixerWorkArea, DRAM + Address, 8);
 		l1 = hleMixerWorkArea[2];
 		l2 = hleMixerWorkArea[3];
 	}
@@ -281,5 +281,5 @@ void POLEF()
 
 	hleMixerWorkArea[2] = l1;
 	hleMixerWorkArea[3] = l2;
-	memcpy((rdram + Address), (u8 *)hleMixerWorkArea, 8);
+	memcpy(DRAM + Address, (u8 *)hleMixerWorkArea, 8);
 }

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -81,8 +81,8 @@ void RESAMPLE() {
 	if ((Flags & 0x1) == 0) {
 		//memcpy (src+srcPtr, rdram+addy, 0x8);
 		for (int x = 0; x < 4; x++)
-			src[MES(srcPtr + x)] = ((u16 *)rdram)[MES((addy / 2) + x)];
-		Accum = *(u16 *)(rdram + addy + 10);
+			src[MES(srcPtr + x)] = ((u16 *)DRAM)[MES((addy / 2) + x)];
+		Accum = *(u16 *)(DRAM + addy + 10);
 	}
 	else {
 		for (int x = 0; x < 4; x++)
@@ -115,9 +115,9 @@ void RESAMPLE() {
 		Accum &= 0xffff;
 	}
 	for (int x = 0; x < 4; x++)
-		((u16 *)rdram)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
+		((u16 *)DRAM)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
 	//memcpy (RSWORK, src+srcPtr, 0x8);
-	*(u16 *)(rdram + addy + 10) = (u16)Accum;
+	*(u16 *)(DRAM + addy + 10) = (u16)Accum;
 }
 
 void RESAMPLE2() {
@@ -140,8 +140,8 @@ void RESAMPLE2() {
 
 	if ((Flags & 0x1) == 0) {
 		for (int x = 0; x < 4; x++) //memcpy (src+srcPtr, rdram+addy, 0x8);
-			src[MES(srcPtr + x)] = ((u16 *)rdram)[MES((addy / 2) + x)];
-		Accum = *(u16 *)(rdram + addy + 10);
+			src[MES(srcPtr + x)] = ((u16 *)DRAM)[MES((addy / 2) + x)];
+		Accum = *(u16 *)(DRAM + addy + 10);
 	}
 	else {
 		for (int x = 0; x < 4; x++)
@@ -161,8 +161,8 @@ void RESAMPLE2() {
 		Accum &= 0xffff;
 	}
 	for (int x = 0; x < 4; x++)
-		((u16 *)rdram)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
-	*(u16 *)(rdram + addy + 10) = (u16)Accum;
+		((u16 *)DRAM)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
+	*(u16 *)(DRAM + addy + 10) = (u16)Accum;
 	//memcpy (RSWORK, src+srcPtr, 0x8);
 }
 
@@ -193,8 +193,8 @@ void RESAMPLE3() {
 
 	if ((Flags & 0x1) == 0) {
 		for (int x = 0; x < 4; x++) //memcpy (src+srcPtr, rdram+addy, 0x8);
-			src[MES(srcPtr + x)] = ((u16 *)rdram)[MES((addy / 2) + x)];
-		Accum = *(u16 *)(rdram + addy + 10);
+			src[MES(srcPtr + x)] = ((u16 *)DRAM)[MES((addy / 2) + x)];
+		Accum = *(u16 *)(DRAM + addy + 10);
 	}
 	else {
 		for (int x = 0; x < 4; x++)
@@ -228,6 +228,6 @@ void RESAMPLE3() {
 		Accum &= 0xffff;
 	}
 	for (int x = 0; x < 4; x++)
-		((u16 *)rdram)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
-	*(u16 *)(rdram + addy + 10) = (u16)Accum;
+		((u16 *)DRAM)[MES((addy / 2) + x)] = src[MES(srcPtr + x)];
+	*(u16 *)(DRAM + addy + 10) = (u16)Accum;
 }

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -125,7 +125,7 @@ void HLEStart() {
 	isMKABI = false;
 	isZeldaABI = false;
 
-	u8  *UData = rdram + UCData;
+	u8 * UData = DRAM + UCData;
 
 	// Detect uCode
 	if (((u32*)UData)[0] != 0x1) {

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -112,13 +112,13 @@ extern "C"
 u32 base, dmembase;
 
 void HLEStart() {
-	u32 List = ((u32*)dmem)[0xFF0 / 4], ListLen = ((u32*)dmem)[0xFF4 / 4];
-	u32 *HLEPtr = (u32 *)(rdram + List);
+	u32 List = ((u32*)DMEM)[0xFF0 / 4], ListLen = ((u32*)DMEM)[0xFF4 / 4];
+	u32 *HLEPtr = (u32 *)(DRAM + List);
 
-	UCData = ((u32*)dmem)[0xFD8 / 4];
-	UDataLen = ((u32*)dmem)[0xFDC / 4];
-	base = ((u32*)dmem)[0xFD0 / 4];
-	dmembase = ((u32*)dmem)[0xFD8 / 4];
+	UCData = ((u32*)DMEM)[0xFD8 / 4];
+	UDataLen = ((u32*)DMEM)[0xFDC / 4];
+	base = ((u32*)DMEM)[0xFD0 / 4];
+	dmembase = ((u32*)DMEM)[0xFD8 / 4];
 
 	loopval = 0;
 	memset(SEGMENTS, 0, 0x10 * 4);

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -70,6 +70,9 @@ extern u32 t9, k0;
 #define dmem	AudioInfo.DMEM
 #define imem	AudioInfo.IMEM
 #define rdram	AudioInfo.RDRAM
+extern u8 * DMEM;
+extern u8 * IMEM;
+extern u8 * DRAM;
 
 // Use these functions to interface with the HLE Audio...
 void HLEStart ();

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -67,7 +67,6 @@ extern u32 t9, k0;
 
 // These must be defined...
 #include "AudioSpec.h"
-#define dmem	AudioInfo.DMEM
 #define imem	AudioInfo.IMEM
 #define rdram	AudioInfo.RDRAM
 extern u8 * DMEM;

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -67,7 +67,6 @@ extern u32 t9, k0;
 
 // These must be defined...
 #include "AudioSpec.h"
-#define imem	AudioInfo.IMEM
 #define rdram	AudioInfo.RDRAM
 extern u8 * DMEM;
 extern u8 * IMEM;

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -63,16 +63,14 @@
 
 //------------------------------------------------------------------------------------------
 
+// Use these functions to interface with the HLE Audio...
+#include "AudioSpec.h"
+
 extern u32 t9, k0;
 
-// These must be defined...
-#include "AudioSpec.h"
 extern u8 * DMEM;
 extern u8 * IMEM;
 extern u8 * DRAM;
-
-// Use these functions to interface with the HLE Audio...
-void HLEStart ();
 
 extern u32 UCData, UDataLen;
 

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -67,7 +67,6 @@ extern u32 t9, k0;
 
 // These must be defined...
 #include "AudioSpec.h"
-#define rdram	AudioInfo.RDRAM
 extern u8 * DMEM;
 extern u8 * IMEM;
 extern u8 * DRAM;

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -214,6 +214,10 @@ DWORD junk;
 DWORD RSPRegs[10];
 BOOL audioIsInitialized = FALSE;
 
+u8 * DMEM;
+u8 * IMEM;
+u8 * DRAM;
+
 EXPORT BOOL CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 
 	//RedirectIOToConsole();
@@ -234,7 +238,11 @@ EXPORT BOOL CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 	//snd.configDevice = 0;
 	snd.configVolume = 0;
 
-	memcpy (&AudioInfo, &Audio_Info, sizeof(AUDIO_INFO));
+	memcpy(&AudioInfo, &Audio_Info, sizeof(AUDIO_INFO));
+	DRAM = Audio_Info.RDRAM;
+	DMEM = Audio_Info.DMEM;
+	IMEM = Audio_Info.IMEM;
+
 	audioIsInitialized = !snd.Initialize (AudioInfo.hwnd);
 	if (audioIsInitialized == TRUE) snd.SetVolume(snd.configVolume);
 /*	RSPInfo.DMEM = AudioInfo.DMEM;


### PR DESCRIPTION
Instead of
```c
#define dmem    AudioInfo.DMEM
```
we also can do
```c
u8 * DMEM = AudioInfo.DMEM;
```

My personal preference is the latter, as this non-macro variant is a bit more protected against linguistic intervention by the C pre-processor.  For example, with the macro you can't name the define `DMEM` because that's recursive due to DMEM being also the name of the member of the AudioInfo struct.

I also think that writing "DMEM" instead of "dmem" is grammatically clearer (less likely to be confused for an abbreviation instead of an acronym, which almost always must be uppercase), though that's a separate issue.

This should have no effect on performance since it's just a pointer assigned to a pre-existing pointer, but I tested the changes with Conker's and Mario anyway.