### PR TITLE
better clamping in ABI_Filters

### DIFF
--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -143,17 +143,7 @@ void FILTER2() {
 			out1[i]  += 0x4000;
 		for (i = 0; i < 8; i++)
 			out1[i] >>= 15;
-#if 1
-/*
- * Clamp the result to fit within the legal range of 16-bit short elements.
- * VMULF, I know, never needs this in games, because the only way for VMULF
- * to produce an out-of-range value is if audio ucode does -32768 * -32768.
- */
-		for (i = 0; i < 8; i++)
-			assert(out1[i] >= -32768 && out1[i] <= +32767);
-		for (i = 0; i < 8; i++)
-			outp[i] = pack_signed(out1[i]);
-#endif
+		vsats128(&outp[0], &out1[0]);
 		outp += 8;
 
 		inp1 = inp2 + 0;

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -140,17 +140,19 @@ void FILTER2() {
 		packed_multiply_accumulate(&out1[7], &inputs_matrix[1], &lutt6[0]);
 
 		for (i = 0; i < 8; i++)
-			outp[i] = (s16)((out1[i] + 0x4000) >> 15); /* fractional round and shift */
-#if 0
+			out1[i]  += 0x4000;
+		for (i = 0; i < 8; i++)
+			out1[i] >>= 15;
+#if 1
 /*
  * Clamp the result to fit within the legal range of 16-bit short elements.
  * VMULF, I know, never needs this in games, because the only way for VMULF
  * to produce an out-of-range value is if audio ucode does -32768 * -32768.
  */
 		for (i = 0; i < 8; i++)
-			assert(outp[i] >= -32768 && outp[i] <= +32767);
+			assert(out1[i] >= -32768 && out1[i] <= +32767);
 		for (i = 0; i < 8; i++)
-			outp[i] = pack_signed(outp[i]);
+			outp[i] = pack_signed(out1[i]);
 #endif
 		outp += 8;
 


### PR DESCRIPTION
Faster actually, though that wasn't the intention.

The problem was the assert() I inserted a while back to check if outp[] fit in range of a s16 after:
```c
for (i = 0; i < 8; i++)
    outp[i] = (s16)((out1[i] + 0x4000) >> 15); /* fractional round and shift */
```
Which was dumb because outp[] already was an array of s16's (plus the typecast), so the assert was useless for debugging.

I ended up forcing the signed clamp respective to VMULF to happen anyway, as there is no performance loss from doing so if you have SSE enabled.  In fact, vsats128() is even faster actually than just doing array16[i] = array32[i] & 0x0000FFFF; since no SIMD instruction on the Intel ISA corresponds to that.  So unintentionally this should have improved speed anyway.  Tested with OOT + MK64.