### PR TITLE
Visual Studio project cleanup

### DIFF
--- a/AziAudio.vs2013.sln
+++ b/AziAudio.vs2013.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AziAudio", "AziAudio\AziAudio.vcxproj", "{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AziAudio", "AziAudio\AziAudio.vcxproj", "{835979AC-BC6A-45B7-A513-8EEE79B443DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,14 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|Win32.ActiveCfg = Debug|Win32
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|Win32.Build.0 = Debug|Win32
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|x64.ActiveCfg = Debug|x64
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Debug|x64.Build.0 = Debug|x64
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|Win32.ActiveCfg = Release|Win32
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|Win32.Build.0 = Release|Win32
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|x64.ActiveCfg = Release|x64
-		{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}.Release|x64.Build.0 = Release|x64
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Debug|Win32.ActiveCfg = Debug|Win32
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Debug|Win32.Build.0 = Debug|Win32
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Debug|x64.ActiveCfg = Debug|x64
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Debug|x64.Build.0 = Debug|x64
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Release|Win32.ActiveCfg = Release|Win32
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Release|Win32.Build.0 = Release|Win32
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Release|x64.ActiveCfg = Release|x64
+		{835979AC-BC6A-45B7-A513-8EEE79B443DE}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -52,9 +52,6 @@
       <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <OutputFile Condition="'$(Configuration)'=='Debug'">$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-    </Link>
-    <Link>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)3rd Party\directx\lib\x86</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(SolutionDir)3rd Party\directx\lib\x64</AdditionalLibraryDirectories>
       <AdditionalDependencies>dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -17,7 +17,7 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-  </ItemGroup<name />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{835979AC-BC6A-45B7-A513-8EEE79B443DE}</ProjectGuid>
     <RootNamespace>AziAudio</RootNamespace>

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{2349B0DB-9745-4055-AD9A-E3B3F15CD0D7}</ProjectGuid>
+    <ProjectGuid>{835979AC-BC6A-45B7-A513-8EEE79B443DE}</ProjectGuid>
     <RootNamespace>AziAudio</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -17,7 +17,7 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-  </ItemGroup>
+  </ItemGroup<name />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{835979AC-BC6A-45B7-A513-8EEE79B443DE}</ProjectGuid>
     <RootNamespace>AziAudio</RootNamespace>
@@ -28,7 +28,7 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release'">
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -31,9 +31,6 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -41,29 +38,18 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(SolutionDir)PropertySheets\Win32.$(Configuration).props" />
   </ImportGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <TargetName>$(ProjectName)_d</TargetName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <TargetName>$(ProjectName)_d</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)3rd Party\directx\include</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)3rd Party\directx\include</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)3rd Party\directx\include</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)3rd Party\directx\include</AdditionalIncludeDirectories>
-      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Full</Optimization>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AnySuitable</InlineFunctionExpansion>
-      <IntrinsicFunctions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</IntrinsicFunctions>
-      <FavorSizeOrSpeed Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Neither</FavorSizeOrSpeed>
-      <WholeProgramOptimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</WholeProgramOptimization>
-      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Full</Optimization>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AnySuitable</InlineFunctionExpansion>
-      <IntrinsicFunctions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IntrinsicFunctions>
-      <FavorSizeOrSpeed Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Neither</FavorSizeOrSpeed>
-      <WholeProgramOptimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</WholeProgramOptimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rd Party\directx\include</AdditionalIncludeDirectories>
+      <Optimization Condition="'$(Configuration)'=='Release'">Full</Optimization>
+      <InlineFunctionExpansion Condition="'$(Configuration)'=='Release'">AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions Condition="'$(Configuration)'=='Release'">true</IntrinsicFunctions>
+      <FavorSizeOrSpeed Condition="'$(Configuration)'=='Release'">Neither</FavorSizeOrSpeed>
+      <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <OutputFile Condition="'$(Configuration)'=='Debug'">$(OutDir)$(TargetName)$(TargetExt)</OutputFile>


### PR DESCRIPTION
Made the UIDs same for the VS2013 and VS2008 projects, set the VS2013 project to build for XP, fixed the debug output directory in VS2013, and cleaned up a few redundancies in the VS2013 project.