### PR TITLE
64-bit compilation fix (macro preprocessor regression caused by me)

### DIFF
--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -352,7 +352,7 @@ void vsats64 (s16* vd, s32* vs)
     __m128i xmm;
 
     xmm = _mm_loadu_si128((__m128i *)vs);
-    xmm = _mm_packs_pi32(xmm, xmm);
+    xmm = _mm_packs_epi32(xmm, xmm);
     *(i64 *)vd = _mm_cvtsi128_si64(xmm);
 #elif defined(SSE1_SUPPORT) || defined(SSE2_SUPPORT)
     __m64 result, mmx_hi, mmx_lo;

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -131,8 +131,12 @@ extern s16 acc_clamped[N];
 
 /*
  * Include the SSE2 headers if MSVC is set to target SSE2 in code generation.
+ * [Update 2015.07.08 ... or if targeting Intel x86_64.]
  */
 #if defined(_M_IX86_FP) && (_M_IX86_FP >= 2)
+#include <emmintrin.h>
+#endif
+#if defined(_M_X64)
 #include <emmintrin.h>
 #endif
 


### PR DESCRIPTION
To begin, I would like to point out that this plugin does work on 64-bit Project64 2.x, _with some changes_.

However because zilmar currently is a ![Slowpoke](http://www.froster.org/forum/style_emoticons/default/slowpoke.png) (sorry :D) with merging the more important, needed changes so that the upstream and official Project64 64-bit works, I have made [64-bit Project64 1.4](https://github.com/cxd4/Project64_64) here, which also works with this plugin.

When I pulled from master I just had to fix a couple build issues, and it works again.

There was a crash with Zelda MM in 64-bit audio HLE but that seems to have been fixed by pulling the commits I pushed a while back to fix the function pointer size memcpy'ing in the HLEMain function.  So it looks like this plugin pretty much works flawlessly in 64-bit.