### PR TITLE
added option to build using the (older, XP-compatible) Windows DDK

### DIFF
--- a/make_wdk.cmd
+++ b/make_wdk.cmd
@@ -1,0 +1,41 @@
+@ECHO OFF
+TITLE Windows Driver Kit 7.1.0
+
+set src=%CD%\AziAudio
+set obj=%CD%
+
+REM set target=i386
+set target=amd64
+
+set DDK=C:\WinDDK\7600.16385.1
+set MSVC=%DDK%\bin\x86\%target%
+set incl=/I"%DDK%\inc\crt" /I"%DDK%\inc\api" /I"%DDK%\inc\api\crt\stl60" /I"%src%\..\3rd Party\directx\include"
+set libs=/LIBPATH:"%DDK%\lib\crt\%target%" /LIBPATH:"%DDK%\lib\wnet\%target%"
+
+set C_FLAGS=/W4 /Ox /Ob2 /Gm /Zi /Oi /GS- /EHa /MD
+set LINK_FLAGS=%libs% kernel32.lib user32.lib ole32.lib /DLL
+
+set files=%src%\main.cpp^
+ %src%\ABI_Adpcm.cpp^
+ %src%\ABI_Buffers.cpp^
+ %src%\ABI_Envmixer.cpp^
+ %src%\ABI_Filters.cpp^
+ %src%\ABI_MixerInterleave.cpp^
+ %src%\ABI_Resample.cpp^
+ %src%\ABI1.cpp^
+ %src%\ABI2.cpp^
+ %src%\ABI3.cpp^
+ %src%\ABI3mp3.cpp^
+ %src%\DirectSoundDriver.cpp^
+ %src%\HLEMain.cpp^
+ %src%\SoundDriver.cpp^
+ %src%\WaveOut.cpp^
+ %src%\XAudio2SoundDriver.cpp^
+ %src%\Mupen64plusHLE\audio.c^
+ %src%\Mupen64plusHLE\memory.c^
+ %src%\Mupen64plusHLE\Mupen64Support.c^
+ %src%\Mupen64plusHLE\musyx.c
+
+%MSVC%\cl.exe %files% %incl% %C_FLAGS% /link /OUT:AziAudio.dll %LINK_FLAGS%
+
+pause

--- a/make_wdk.cmd
+++ b/make_wdk.cmd
@@ -13,7 +13,7 @@ set incl=/I"%DDK%\inc\crt" /I"%DDK%\inc\api" /I"%DDK%\inc\api\crt\stl60" /I"%src
 set libs=/LIBPATH:"%DDK%\lib\crt\%target%" /LIBPATH:"%DDK%\lib\wnet\%target%"
 
 set C_FLAGS=/W4 /Ox /Ob2 /Gm /Zi /Oi /GS- /EHa /MD
-set LINK_FLAGS=%libs% kernel32.lib user32.lib ole32.lib /DLL
+set LINK_FLAGS=%libs% kernel32.lib user32.lib ole32.lib %obj%\resource.res /DLL
 
 set files=%src%\main.cpp^
  %src%\ABI_Adpcm.cpp^
@@ -36,6 +36,7 @@ set files=%src%\main.cpp^
  %src%\Mupen64plusHLE\Mupen64Support.c^
  %src%\Mupen64plusHLE\musyx.c
 
+%DDK%\bin\x86\rc.exe %incl% /fo %obj%\resource.res %src%\resource.rc
 %MSVC%\cl.exe %files% %incl% %C_FLAGS% /link /OUT:AziAudio.dll %LINK_FLAGS%
 
 pause


### PR DESCRIPTION
I wanted to make an issue about this but needed to show how the script would look, so here the "issue" is in pull request form.  Possibly this should be rejected instead of merged; it depends what we want.

The reason I like to do this is so we can link against MSVCRT.DLL, instead of statically linking with /MT like zilmar does over at Project64 or dynamically linking MSVCR80, MSVCR90, ... whatever which people won't necessarily have installed on their system or understand why the plugin fails to initialize.

MSVCRT.DLL is the "known DLL" on all versions of Windows ever since Windows 95 b and is what the components to today's versions of the Windows operating system continue to use, despite forcing all other developers to use the MSVCR80, 90, 100... series of numbered and non-universal DLL's.  (The reason this started was because it became infeasible over time for Microsoft to update their C library over every release with the same unified "msvcrt.dll" filename with new features, such as MSVC or C99 extensions and support, which commonly serve no meaningful value for simple engineering.)

So maybe it sounds absurdly unorthodox to use the Windows Driver Kit and maybe these changes should be declined; I can also understand it that way if the CRT library issue takes overall less priority than the VS environment or debugging etc..  I had a couple good long reads from some of these people who also like to do this to centralize their standard C to a universally available, external library from these blogs:

https://kobyk.wordpress.com/2007/07/20/dynamically-linking-with-msvcrtdll-using-visual-c-2005/
http://www.syndicateofideas.com/posts/fighting-the-msvcrt-dll-hell

The result of these changes is that my AziAudio.dll is about 100 KB, while the AziAudio.dll produced from the VS2013 solution in this repository using /MT (static multi-threaded) is over 150 KB.  Screenshot of the new DLL's analysis in Dependency Walker:
![azicrt](https://cloud.githubusercontent.com/assets/1396303/8629622/da16df1a-272a-11e5-94ad-104b737060f2.png)

The only thing I have not figured out how to do is dynamically link a universal variant of the MSVCP* libraries (C++ counterparts to MSVCRT.DLL).  I guess in the WDK that gets statically linked, but there are only 4 C++ functions being used in AziAudio so maybe by removing those that issue could be subsetted out anyway down to just dynamically linked MSVCR, absolutely no MSVCP dependency (meaning neither static- nor dynamic-linked).