### PR TITLE
more warning fixes

### DIFF
--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -29,7 +29,7 @@
 // TODO: Clean this up a bit...
 DWORD last_pos = 0, write_pos = 0, play_pos = 0, temp = 0, next_pos = 0;
 DWORD last_play = 0;
-DWORD last_write = -1;
+DWORD last_write = ~0u;
 LPVOID lpvPtr1, lpvPtr2;
 DWORD dwBytes1, dwBytes2;
 int AudioInterruptTime = -1;
@@ -147,7 +147,7 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 	while (ac->audioIsDone == false) { // While the thread is still alive
 		while (last_pos == write_pos) { // Cycle around until a new buffer position is available
 			if (lpdsbuff == NULL)
-				ExitThread(-1);
+				ExitThread(~0u);
 			// Check to see if the audio pointer moved on to the next segment
 			if (write_pos == last_pos) {
 				Sleep (1);
@@ -730,7 +730,7 @@ DWORD DirectSoundDriver::GetReadStatus() {
 
 void DirectSoundDriver::SetVolume(DWORD volume) {
 	DWORD dsVolume = (DWORD)((volume * -25));
-	if (volume == 100) dsVolume = DSBVOLUME_MIN;
+	if (volume == 100) dsVolume = (DWORD)DSBVOLUME_MIN;
 	if (volume = 0) dsVolume = DSBVOLUME_MAX;
 	if (lpdsb != NULL) lpdsb->SetVolume(dsVolume);
 }

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -322,7 +322,7 @@ _exit_:
 	ReleaseMutex(ac->hMutex);
 	ac->handleAudioThread = NULL;
 	ExitThread(0);
-	return 0;
+//	return 0;
 }
 
 
@@ -502,8 +502,8 @@ void DirectSoundDriver::AiUpdate(BOOL Wait) {
 
 	if (Wait)
 		WaitMessage();
-	return;
 
+#if 0
 	if (configForceSync && (*AudioInfo.AI_STATUS_REG & 0x80000000)) {
 		if (remainingBytes < LOCK_SIZE * 2) {
 			*AudioInfo.AI_STATUS_REG &= ~0x80000000;
@@ -512,6 +512,7 @@ void DirectSoundDriver::AiUpdate(BOOL Wait) {
 			interruptcnt--;
 		}
 	}
+#endif
 }
 
 #ifdef STREAM_DMA
@@ -705,9 +706,10 @@ DWORD DirectSoundDriver::GetReadStatus() {
 	if (configAIEmulation == true) {
 #ifdef STREAM_DMA
 		return DMALen[0] & ~7;
-		if (remainingBytes < LOCK_SIZE)
-			return 0;
-		else return DMALen[0] & ~3;
+	//	if (remainingBytes < LOCK_SIZE)
+	//		return 0;
+	//	else
+	//		return DMALen[0] & ~3;
 #else
 		if (remainingBytes < (LOCK_SIZE * 2)) {
 			return 0;

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -49,7 +49,7 @@ DWORD interruptcnt = 0;
 #ifdef STREAM_DMA
 void DirectSoundDriver::FillBuffer(BYTE *buff, DWORD len) {
 	DWORD cnt = 0;
-	DWORD writeCnt = 0;
+//	DWORD writeCnt = 0;
 	DWORD lastValue = 0;
 	// Fill buffer from play buffer
 	if (remainingBytes >= LOCK_SIZE)
@@ -130,7 +130,7 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 	DWORD dwStatus;
 	DWORD last_play_pos = 0, bytesMoved = 0;
 	//LPDIRECTSOUNDBUFFER8  lpdsbuf = ac->lpdsbuf;
-	LPDIRECTSOUND8        lpds = ac->lpds;
+//	LPDIRECTSOUND8        lpds = ac->lpds;
 
 	lpdsbuff = ac->lpdsbuf;
 
@@ -214,8 +214,8 @@ DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 				writeOut = 0;
 				else
 				writeOut = LOCK_SIZE/8;			*/
-				DWORD SavedDMALen0 = DMALen[0];
-				DWORD SavedDMALen1 = DMALen[1];
+			//	DWORD SavedDMALen0 = DMALen[0];
+			//	DWORD SavedDMALen1 = DMALen[1];
 				while (writeCnt != writeOut && DMAData[0] > 0)
 				{
 					ac->SoundBuffer[ac->writeLoc++] = DMAData[0][2];

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -11,9 +11,6 @@
 
 #include "common.h"
 #ifndef USE_XAUDIO2
-#pragma warning(disable : 4100)
-#include <dsound.h>
-#pragma warning(default : 4100)
 #include <stdio.h>
 #include "DirectSoundDriver.h"
 #include "AudioSpec.h"

--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -12,9 +12,7 @@
 #pragma once
 
 #include "common.h"
-#pragma warning(disable : 4100)
 #include <dsound.h>
-#pragma warning(default : 4100)
 #include "SoundDriver.h"
 
 static DWORD sLOCK_SIZE;

--- a/AziAudio/Mupen64plusHLE/Mupen64Support.c
+++ b/AziAudio/Mupen64plusHLE/Mupen64Support.c
@@ -6,24 +6,32 @@
 #include "hle_external.h"
 #include "hle_internal.h"
 #include "../AudioSpec.h"
-#pragma warning(disable : 4100)
-void HleWarnMessage(void* UNUSED(user_defined), const char *message, ...)
+
+void HleWarnMessage(void* user_defined, const char *message, ...)
 {
 	va_list args;
 	va_start(args, message);
 	//DebugMessage(M64MSG_WARNING, message, args);
 	va_end(args);
+
+	if (user_defined == NULL)
+		return;
+ /* user_defined possibly as a HWND, FILE pointer, window ID, ... ? */
 }
 
 
-void HleVerboseMessage(void* UNUSED(user_defined), const char *message, ...)
+void HleVerboseMessage(void* user_defined, const char *message, ...)
 {
 	va_list args;
 	va_start(args, message);
 	//DebugMessage(M64MSG_VERBOSE, message, args);
 	va_end(args);
+
+	if (user_defined == NULL)
+		return;
+ /* user_defined possibly as a HWND, FILE pointer, window ID, ... ? */
 }
-#pragma warning(default : 4100)
+
 
 static struct hle_t _hle;
 


### PR DESCRIPTION
At first I was only trying to remove a couple `#pragma warning disable`'s and do more internal warning fixing, but then I discovered that in DirectSound builds of this plugin, there were tens of warnings left unattended so I also ended up fixing those.

I also ended up removing the #pragma warning disable around `#include <dsound.h>` because, /W4 in either 32- or 64-bit builds is not giving me any warnings??  Azimer maybe it's including a dsound.h other than the one the repository supplies and that is why you got warnings from including it.