### PR TITLE
removed unused MMX clamp fallback

### DIFF
--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -346,29 +346,6 @@ void vsats128(s16* vd, s32* vs)
         vd[i] = pack_signed(vs[i]);
 #endif
 }
-void vsats64 (s16* vd, s32* vs)
-{
-#if defined (_M_X64)
-    __m128i xmm;
-
-    xmm = _mm_loadu_si128((__m128i *)vs);
-    xmm = _mm_packs_epi32(xmm, xmm);
-    *(i64 *)vd = _mm_cvtsi128_si64(xmm);
-#elif defined(SSE1_SUPPORT) || defined(SSE2_SUPPORT)
-    __m64 result, mmx_hi, mmx_lo;
-
-    mmx_hi = *(__m64 *)&vs[0];
-    mmx_lo = *(__m64 *)&vs[2];
-    result = _mm_packs_pi32(mmx_hi, mmx_lo);
-    *(__m64 *)vd = result;
-    _mm_empty();
-#else
-    register size_t i;
-
-    for (i = 0; i < 4; i++)
-        vd[i] = pack_signed(vs[i]);
-#endif
-}
 #endif
 
 void copy_vector(void * vd, const void * vs)

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -187,11 +187,8 @@ extern s16 pack_signed(s32 slice);
 #define vsats128(vd, vs) {      \
 vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); \
 vd[2] = pack_signed(vs[2]); vd[3] = pack_signed(vs[3]); }
-#define vsats64(vd, vs) {       \
-vd[0] = pack_signed(vs[0]); vd[1] = pack_signed(vs[1]); }
 #else
 extern void vsats128(s16* vd, s32* vs); /* Clamp vectors using SSE2. */
-extern void vsats64 (s16* vd, s32* vs); /* Clamp vectors using MMX. */
 #endif
 
 /*


### PR DESCRIPTION
RSP doesn't work in terms of 8-byte vectors, so we don't need a 64-bit clamp function--with or without SSE or MMX.  I'm only removing this now because it used a 64-bit compiler intrinsic that older versions of MSVC (such as the Windows DDK build script I recently PR'd into this repo) do not recognize.  The dependency was unnecessary anyway since this function's very existence can give the misleading impression that it's useful for direct RSP emulation.