### PR TITLE
Fix possible [MinGW only?] build error when compiling DirectSound.

### DIFF
--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -11,6 +11,10 @@
 
 #pragma once
 
+#if defined(_WIN32) && !defined(_XBOX)
+#include <mmreg.h>
+#endif
+
 #include "common.h"
 #include <dsound.h>
 #include "SoundDriver.h"

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -18,7 +18,6 @@
 #else
 #include <windows.h>
 #include <commctrl.h>
-#include <mmreg.h>
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
fixes a possible compiler error from commit https://github.com/Azimer/AziAudio/commit/6b27f7a74928266853f8181740a4359a0612a0e7

At the least, GCC exposes this compiler error due to using the "3rd Party" folder for the DirectX includes, which conflicts with the pre-existing type definition of `typedef struct WAVEFORMATEXTENSIBLE`.  (The conflict happens between `<mmreg.h>` and "3rd Party" `<audiodefs.h>`.)