### PR TITLE
ADDMIXER:  fixed null function by adding writeback

### DIFF
--- a/AziAudio/ABI_MixerInterleave.cpp
+++ b/AziAudio/ABI_MixerInterleave.cpp
@@ -22,7 +22,7 @@ void ADDMIXER() {
 	outp = (s16 *)(BufferSpace + OutBuffer);
 	for (s16 cntr = 0; cntr < Count; cntr += 2) {
 		temp = *outp + *inp;
-		temp = pack_signed(temp);
+		*outp = pack_signed(temp);
 		outp++;	inp++;
 	}
 }


### PR DESCRIPTION
Seems to have been a bug since before AziAudio 0.55.1 old versions, as discussed here:  https://github.com/Azimer/AziAudio/issues/121

I don't know yet what parts of audio in what games this change fixes.