### PR TITLE
fixed GNU assembler error messages

### DIFF
--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -67,6 +67,16 @@
  */
 #define N       8
 
+/*
+ * Sometimes the audio HLE code has variables named "k0", after the MIPS GPR.
+ *
+ * With some compilers (like GCC with -masm=intel), this creates assembler
+ * error messages because k0 conflicts with the assembly language syntax.
+ *
+ * Just a little bit of name-mangling should fix this collision.
+ */
+#define k0      GPR_k0
+
 //------------------------------------------------------------------------------------------
 
 // Use these functions to interface with the HLE Audio...


### PR DESCRIPTION
This commit fixes assemble-time errors with building AziAudio using GCC or MinGW.

The error arises when compiling with `masm=intel`, as AT&T is the default x86 syntax for GCC.
```
no@no-laptop:~/AziAudio$ ./make.sh
Compiling sources...
Assembling compiled sources...
./gccbuild/ABI3mp3.asm: Assembler messages:
./gccbuild/ABI3mp3.asm:1231: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm: Assembler messages:
./gccbuild/ABI_Adpcm.asm:189: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm:482: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm:856: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm:1130: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm:1189: Error: invalid use of register
./gccbuild/ABI_Adpcm.asm:1248: Error: invalid use of register
./gccbuild/ABI_Buffers.asm: Assembler messages:
./gccbuild/ABI_Buffers.asm:13: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:29: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:56: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:74: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:144: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:210: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:297: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:437: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:462: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:515: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:541: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:585: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:608: Error: invalid use of register
./gccbuild/ABI_Buffers.asm:646: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm: Assembler messages:
./gccbuild/ABI_Envmixer.asm:10: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:170: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:645: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1039: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1066: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1170: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1285: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1301: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1337: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1687: Error: invalid use of register
./gccbuild/ABI_Envmixer.asm:1749: Error: invalid use of register
./gccbuild/ABI_Filters.asm: Assembler messages:
./gccbuild/ABI_Filters.asm:73: Error: invalid use of register
./gccbuild/ABI_Filters.asm:298: Error: invalid use of register
./gccbuild/ABI_Filters.asm:322: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm: Assembler messages:
./gccbuild/ABI_MixerInterleave.asm:24: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:88: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:185: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:221: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:334: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:411: Error: invalid use of register
./gccbuild/ABI_MixerInterleave.asm:470: Error: invalid use of register
./gccbuild/ABI_Resample.asm: Assembler messages:
./gccbuild/ABI_Resample.asm:61: Error: invalid use of register
./gccbuild/ABI_Resample.asm:228: Error: invalid use of register
./gccbuild/ABI_Resample.asm:393: Error: invalid use of register
./gccbuild/HLEMain.asm: Assembler messages:
./gccbuild/HLEMain.asm:171: Error: invalid use of register
```
Every single one of these errors is fixed with just this one change in this PR.

The problem is declaring variables named things like "k0".
example, from the first of those errors I just pasted:
```asm
    mov     rax, QWORD PTR k0@GOTPCREL[rip]
```
Either `#define`ing k0 as a macro for a different variable name or going through all of the HLE code to change sensitive variable names like k0, s0, t1, a1, a2 and other MIPS register names into stuff like GPR[K0], GPR[S0], GPR[T1] and so on with macro indices seems like a good solution to this problem.

But I chose the smaller solution and supposed we would prefer that method.