### PR TITLE
fixed LLP64 ABI conflict confusing C++ between u32 and DWORD

### DIFF
--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -469,7 +469,7 @@ void DirectSoundDriver::DeInitialize() {
 // ---------BLAH--------
 
 // Buffer Functions for the Audio Code
-void DirectSoundDriver::SetFrequency(DWORD Frequency2) {
+void DirectSoundDriver::SetFrequency(u32 Frequency2) {
 
 	DWORD Frequency = Frequency2;
 	BOOL bAudioPlaying = audioIsPlaying;
@@ -516,7 +516,7 @@ void DirectSoundDriver::AiUpdate(BOOL Wait) {
 }
 
 #ifdef STREAM_DMA
-DWORD DirectSoundDriver::AddBuffer(BYTE *start, DWORD length) {
+u32 DirectSoundDriver::AddBuffer(u8 *start, u32 length) {
 	//DWORD retVal = 0;
 
 	if (length == 0) {
@@ -568,8 +568,8 @@ DWORD DirectSoundDriver::AddBuffer(BYTE *start, DWORD length) {
 	return length;
 }
 #else
-DWORD DirectSoundDriver::AddBuffer(BYTE *start, DWORD length) {
-	DWORD retVal = 0;
+u32 DirectSoundDriver::AddBuffer(u8 *start, u32 length) {
+	u32 retVal = 0;
 	DWORD max = remainingBytes + length;
 	// One DMA buffer = one interrupt
 	interruptcnt++;
@@ -700,7 +700,7 @@ void DirectSoundDriver::StartAudio() {
 	//test.BeginWaveOut("D:\\test.wav", 2, 16, SampleRate);
 }
 
-DWORD DirectSoundDriver::GetReadStatus() {
+u32 DirectSoundDriver::GetReadStatus() {
 	if (configForceSync)
 		return 0;//remainingBytes;
 	if (configAIEmulation == true) {

--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -69,8 +69,8 @@ public:
 	void DeInitialize();
 
 	// Buffer Functions for the Audio Code
-	void SetFrequency(DWORD Frequency);		// Sets the Nintendo64 Game Audio Frequency
-	DWORD AddBuffer(BYTE *start, DWORD length);	// Uploads a new buffer and returns status
+	void SetFrequency(u32 Frequency);           // Sets the Nintendo64 Game Audio Frequency
+	u32 AddBuffer(u8 *start, u32 length);       // Uploads a new buffer and returns status
 	void FillBuffer(BYTE *buff, DWORD len);
 	void SetSegmentSize(DWORD length);
 
@@ -79,7 +79,7 @@ public:
 	void StopAudio();							// Stops the Audio PlayBack (as if paused)
 	void StartAudio();							// Starts the Audio PlayBack (as if unpaused)
 
-	DWORD GetReadStatus();						// Returns the status on the read pointer
+	u32 GetReadStatus();						// Returns the status on the read pointer
 
 	void SetVolume(DWORD volume);
 

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -171,7 +171,7 @@ void XAudio2SoundDriver::Teardown()
 	dllInitialized = false;
 }
 
-void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
+void XAudio2SoundDriver::SetFrequency(u32 Frequency)
 {
 	cacheSize = (Frequency / 25) * 4;// (((Frequency * 4) / 100) & ~0x3) * 8;
 	if (Setup() < 0) /* failed to apply a sound device */
@@ -179,7 +179,7 @@ void XAudio2SoundDriver::SetFrequency(DWORD Frequency)
 	g_source->SetSourceSampleRate(Frequency);
 }
 
-DWORD XAudio2SoundDriver::AddBuffer(BYTE *start, DWORD length)
+u32 XAudio2SoundDriver::AddBuffer(u8 *start, u32 length)
 {
 	if (length == 0 || g_source == NULL) {
 		*AudioInfo.AI_STATUS_REG = 0;
@@ -261,7 +261,7 @@ void XAudio2SoundDriver::StartAudio()
 	audioIsPlaying = true;
 }
 
-DWORD XAudio2SoundDriver::GetReadStatus()
+u32 XAudio2SoundDriver::GetReadStatus()
 {
 	XAUDIO2_VOICE_STATE xvs;
 	int retVal;

--- a/AziAudio/XAudio2SoundDriver.h
+++ b/AziAudio/XAudio2SoundDriver.h
@@ -63,15 +63,15 @@ public:
 	void Teardown();
 
 	// Buffer Functions for the Audio Code
-	void SetFrequency(DWORD Frequency);		// Sets the Nintendo64 Game Audio Frequency
-	DWORD AddBuffer(BYTE *start, DWORD length);	// Uploads a new buffer and returns status
+	void SetFrequency(u32 Frequency);           // Sets the Nintendo64 Game Audio Frequency
+	u32 AddBuffer(u8 *start, u32 length);       // Uploads a new buffer and returns status
 
 	// Management functions
 	void AiUpdate(BOOL Wait);
 	void StopAudio();							// Stops the Audio PlayBack (as if paused)
 	void StartAudio();							// Starts the Audio PlayBack (as if unpaused)
 
-	DWORD GetReadStatus();						// Returns the status on the read pointer
+	u32 GetReadStatus();						// Returns the status on the read pointer
 
 	void SetVolume(DWORD volume);
 


### PR DESCRIPTION
When I got the No Sound driver compiling on Linux it required changing the types away from stuff like WORD, DWORD, BYTE ... but this made it inconsistent with the C++ class types used in DirectSound/XAudio because C++ thinks `u32 (unsigned int)` can't be connected to `DWORD (unsigned long)`.

Simply changing the non-Linux code to say u32 instead of DWORD in this case fixes that, too.