### PR TITLE
Fix reset audio with speed limiter off

### DIFF
--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -137,6 +137,7 @@ void SoundDriver::AI_Shutdown()
 
 void SoundDriver::AI_ResetAudio()
 {
+	StopAudio();
 	if (m_audioIsInitialized) DeInitialize();
 	m_audioIsInitialized = false;
 	m_audioIsInitialized = (!Initialize() == TRUE);


### PR DESCRIPTION
Stops sounds sometimes repeating forever when you reset with speed limiter off.