### PR TITLE
Attach NoSound driver for non-Windows, non-Xbox builds.

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -136,14 +136,12 @@ EXPORT Boolean CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 /*
  * To do:  We currently have no sound-playing device for Unix-based platforms.
  */
-#if defined(_WIN32) || defined(_XBOX)
-#ifndef LEGACY_SOUND_DRIVER
+#if !defined(LEGACY_SOUND_DRIVER) || !defined(_WIN32)
 	snd = new NoSoundDriver();
-#elif !defined(USE_XAUDIO2)
-	snd = new DirectSoundDriver();
-#else
+#elif defined(USE_XAUDIO2)
 	snd = new XAudio2SoundDriver();
-#endif
+#else
+	snd = new DirectSoundDriver();
 #endif
 
 	//RedirectIOToConsole();


### PR DESCRIPTION
Alright, my previous approach at a Linux build was a bit short-sighted.

While it does compile on Linux, I've underestimated the degree to which the AI and HLE functions all depend on the `snd` object to store a valid pointer to allocated sound driver class.  Simply keeping it NULL appears to not be an option that goes with the flow of Azimer's intended design.

So, I'm making this little change to attach NoSound driver #ifndef _WIN32 (includes _XBOX) as well.

Yes it will break compiling on Linux with a couple errors about WIN32-isms in the NoSound driver class, but I will be fine to tackle those based on whether these changes look acceptable.