### PR TITLE
Fix regression in AiReadLength

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -254,7 +254,7 @@ EXPORT void CALL AiLenChanged(void)
 EXPORT u32 CALL AiReadLength(void) {
 	if (snd == NULL)
 		return 0;
-	if (audioIsInitialized == FALSE) return 0;
+
 	*AudioInfo.AI_LEN_REG = snd->AI_ReadLength();
 	return *AudioInfo.AI_LEN_REG;
 


### PR DESCRIPTION
audioIsInitialized always = false, when I checked. This made it always
return 0. It already checks if audio is initialized in
snd->AI_ReadLength(). This commit fixes the problem in WDC where there
is no sound when fixed audio timing is disabled.