### PR TITLE
Finally get the plugin to actually run on Linux.

### DIFF
--- a/AziAudio/NoSoundDriver.cpp
+++ b/AziAudio/NoSoundDriver.cpp
@@ -35,11 +35,16 @@ void NoSoundDriver::AiUpdate(Boolean Wait)
 #if defined(_WIN32) || defined(_XBOX)
 	if (Wait == TRUE)
 		Sleep(1);
+#else
+	if (Wait == TRUE)
+		SDL_Delay(1);
 #endif
 	if (isPlaying == true && countsPerSample.QuadPart > 0)
 	{
 #ifdef _WIN32
 		QueryPerformanceCounter(&perfTimer);
+#else
+		// To do:  Replace this with SDL, or Linux audio won't play.
 #endif
 		sampleInterval.QuadPart = perfTimer.QuadPart - perfLast.QuadPart;
 		samples = (long)(sampleInterval.QuadPart / countsPerSample.QuadPart);
@@ -75,5 +80,7 @@ void NoSoundDriver::SetFrequency(u32 Frequency)
 	countsPerSample.QuadPart = perfFreq.QuadPart / SamplesPerSecond;
 	QueryPerformanceCounter(&perfTimer);
 	perfLast.QuadPart = perfTimer.QuadPart;
+#else
+	// To do:  Replace this with SDL, or Linux audio won't play.
 #endif
 }

--- a/AziAudio/SDLSoundDriver.h
+++ b/AziAudio/SDLSoundDriver.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+*                                                                           *
+* Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
+* http://www.apollo64.com/                                                  *
+* Copyright (C) 2000-2015 Azimer. All rights reserved.                      *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+
+#pragma once
+
+#include "SoundDriver.h"
+
+class SDLSoundDriver : public SoundDriver
+{
+public:
+    SDLSoundDriver();
+    ~SDLSoundDriver();
+
+    Boolean Initialize();
+    void DeInitialize();
+
+#ifdef LEGACY_SOUND_DRIVER
+    u32 GetReadStatus();
+    u32 AddBuffer(u8* start, u32 length);
+#endif
+
+    void AiUpdate(Boolean Wait); // optional
+    void StopAudio();            // stops the audio playback (as if paused)
+    void StartAudio();           // starts the audio playback (as if unpaused)
+    void SetFrequency(u32 Frequency);
+
+    void SetVolume(u32 volume);
+protected:
+    bool dllInitialized;
+};

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -11,6 +11,12 @@
 
 #pragma once
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <SDL/SDL.h>
+#endif
+
 /* strcpy() */
 #include <string.h>
 
@@ -19,7 +25,11 @@
 
 #define SND_IS_NOT_EMPTY 0x4000000
 #define SND_IS_FULL		 0x8000000
+
+/* deprecated AI functions -- to be removed */
+#if 1 && defined(_WIN32)
 #define LEGACY_SOUND_DRIVER
+#endif
 
 #if !defined(_WIN32) && !defined(_XBOX)
 #define UNREFERENCED_PARAMETER(msg)     msg

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -11,12 +11,16 @@
 
 #include "common.h"
 #include "AudioSpec.h"
+
 #ifdef USE_XAUDIO2
 #include "XAudio2SoundDriver.h"
 #elif defined(_WIN32)
 #include "DirectSoundDriver.h"
+#else
+#include "SDLSoundDriver.h"
 #endif
 #include "NoSoundDriver.h"
+
 #include "audiohle.h"
 //#include "rsp/rsp.h"
 


### PR DESCRIPTION
Okay, it took me a few days to get over the mental blocks involved, but I've decided on a temporary way to modify the new, anti-LEGACY_SOUND_DRIVER code in `SoundDriver.cpp` to be able to compile on Linux.  Most of the stuff being macro'd out there is about the Windows mutex object and the "wait for object" functions, for which I need to extract a suitable replacement in terms of SDL.

Not that I am any fan of SDL, but the fundamental design of this plugin's newer AI functions to use advanced timing and object functions would overwhelm me if I didn't at least begin to include it, for now.

Since I've already decided to attempt replacing the newer SoundDriver Win32 class code with SDL-ism's, I figured it seemed opportune to also start working on a SDLSoundDriver.cpp -- I have obviously not finished it yet but included a new un-attached header, `SDLSoundDriver.h`, to show my current prototype for beginning it.

Emulation starts on Linux now, but the screen is just black with no output.  I'm not sure if that's the way that AI interrupts are expected to work under Mupen64 or if it's because of my unfinished SDL port of the driver code, but I'll find out soon enough.