### PR TITLE
Remove reference to non-existing property sheets.

### DIFF
--- a/AziAudio.sln
+++ b/AziAudio.sln
@@ -9,12 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertyS
 		PropertySheets\Debug.props = PropertySheets\Debug.props
 		PropertySheets\PlatformBase.props = PropertySheets\PlatformBase.props
 		PropertySheets\Release.props = PropertySheets\Release.props
-		PropertySheets\Win32.Debug.props = PropertySheets\Win32.Debug.props
 		PropertySheets\Win32.props = PropertySheets\Win32.props
-		PropertySheets\Win32.Release.props = PropertySheets\Win32.Release.props
-		PropertySheets\x64.Debug.props = PropertySheets\x64.Debug.props
 		PropertySheets\x64.props = PropertySheets\x64.props
-		PropertySheets\x64.Release.props = PropertySheets\x64.Release.props
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Trivial change.
After removing the `$(Platform).$(Configuration).props` files, references to them were left on `AziAudio.sln`.