### PR TITLE
Created Publish target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bld/
 
 # Visual Studo 2015 cache/options directory
 .vs/
+.vscode/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/AziAudio/AziAudio.vcxproj
+++ b/AziAudio/AziAudio.vcxproj
@@ -116,4 +116,16 @@
     </VisualStudio>
   </ProjectExtensions>
 
+  <ItemGroup>
+    <FilesToDeploy Include="$(OutDir)AziAudio.dll" />
+  </ItemGroup>
+
+  <!--Set Pj64Install as an environment variable or as an MSBuild command-line property.-->
+  <Target Name="Publish">
+    <Message Text="Deploying to [$(Pj64Install)]" />
+    <Message Text="Files to move: [@(FilesToDeploy)]" />
+    <Copy SourceFiles="@(FilesToDeploy)" DestinationFolder="$(Pj64Install)\Plugin\$(PluginType)" Condition="'$(Platform)'=='Win32'" />
+    <Copy SourceFiles="@(FilesToDeploy)" DestinationFolder="$(Pj64Install)\Plugin64\$(PluginType)" Condition="'$(Platform)'=='x64'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
The produced DLL can be deployed to a provided Project64 installation.
Example:
`MSBuild AziAudio.sln /p:Configuration=Release /t:Publish /p:Pj64Install="C:\Games\Project64"`