### PR TITLE
Fix volume control and losing audio on plugin change and load savestate

### DIFF
--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -729,8 +729,8 @@ u32 DirectSoundDriver::GetReadStatus() {
 }
 
 
-void DirectSoundDriver::SetVolume(DWORD volume) {
-	DWORD dsVolume = (DWORD)((volume * -25));
+void DirectSoundDriver::SetVolume(u32 volume) {
+	DWORD dsVolume = ((DWORD)volume * -25);
 	if (volume == 100) dsVolume = (DWORD)DSBVOLUME_MIN;
 	if (volume == 0) dsVolume = DSBVOLUME_MAX;
 	if (lpdsb != NULL) lpdsb->SetVolume(dsVolume);

--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -81,6 +81,6 @@ public:
 
 	u32 GetReadStatus();						// Returns the status on the read pointer
 
-	void SetVolume(DWORD volume);
+	void SetVolume(u32 volume);
 
 };

--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -118,6 +118,7 @@ void SoundDriver::AI_Startup()
 {
 #ifdef LEGACY_SOUND_DRIVER	
 	if (m_audioIsInitialized == true) DeInitialize();
+	m_audioIsInitialized = false;
 	m_audioIsInitialized = (!Initialize() == TRUE);
 	if (m_audioIsInitialized == true) SetVolume(configVolume);
 #else
@@ -136,18 +137,18 @@ void SoundDriver::AI_Startup()
 #else
 	// to do
 #endif
-	StartAudio();
 #endif
+	StartAudio();
 }
 
 void SoundDriver::AI_Shutdown()
 {
+	StopAudio();
 #ifdef LEGACY_SOUND_DRIVER
 	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
 	//DeInitialize();
 #else
-	StopAudio();
 	DeInitialize();
 #ifdef _WIN32
 	if (m_hMutex != NULL)
@@ -164,7 +165,7 @@ void SoundDriver::AI_Shutdown()
 void SoundDriver::AI_ResetAudio()
 {
 	StopAudio();
-	if (m_audioIsInitialized) DeInitialize();
+	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
 	m_audioIsInitialized = (!Initialize() == TRUE);
 	StartAudio();

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -328,6 +328,8 @@ INT_PTR CALLBACK ConfigProc(
 			snd->configRSP = SendMessage(GetDlgItem(hDlg, IDC_RSP), BM_GETSTATE, 0, 0) == BST_CHECKED ? true : false;
 			SelectedDSound = (int)SendMessage(GetDlgItem(hDlg, IDC_DEVICE), CB_GETCURSEL, 0, 0);
 			safe_strcpy(snd->configDevice, 99, DSoundDeviceName[SelectedDSound]);
+			snd->configVolume = SendMessage(GetDlgItem(hDlg, IDC_VOLUME), TBM_GETPOS, 0, 0);
+			snd->SetVolume(snd->configVolume);
 			EndDialog(hDlg, 0);
 			break;
 		case IDCANCEL:

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -206,16 +206,12 @@ EXPORT void CALL RomOpen(void)
 {
 	if (snd == NULL)
 		return;
-	Dacrate = 0;
-	snd->AI_ResetAudio();
 }
 
 EXPORT void CALL RomClosed(void) 
 {
 	if (snd == NULL)
 		return;
-	Dacrate = 0;
-	snd->AI_ResetAudio();
 }
 
 EXPORT void CALL AiDacrateChanged(int SystemType) {


### PR DESCRIPTION
I meant to separate these fixes, but I merged them into one branch by mistake.

Note:  I made these fixes with the win32 hack for an ancient pre 1.5.2 jabo plugin removed from Project64, which calls main twice and creates an empty thread.  It hasn't been merged yet, but can be built from here:
https://github.com/Frank-74/project64/tree/Remove-pjutilDynLibCallDllMain()