### PR TITLE
secure, simpler config file initialization

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -195,9 +195,9 @@ EXPORT Boolean CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 	snd->configSyncAudio   = (azicfg[0] != 0x00) ? true : false;
 	snd->configForceSync   = (azicfg[1] != 0x00) ? true : false;
 	snd->configAIEmulation = (azicfg[2] != 0x00) ? true : false;
-	snd->configVolume      = azicfg[3];
-	snd->AI_Startup();
+	snd->configVolume      = (azicfg[3] > 100) ? 100 : azicfg[3];
 
+	snd->AI_Startup();
 	return TRUE;
 }
 


### PR DESCRIPTION
A number of things being addressed:

1.  Calling `fread(azicfg, size, 1, file)` without a return value is bad.  That means if the config file was only 3, 2 or less than `size` bytes, no bytes would be imported at all.  Switching it around to `fread(azicfg, 1, size, file)` would have at least written what was available, but you should still check for the return value to see how many bytes were accessed without errors.
2.  Using `malloc` based on the file size of the config file could mistakenly allocate several GB of RAM if the config file name happened to represent some binary file other than the intended AziAudio configuration.  If Config/AziCfg.bin was really some other file just named wrongly and was say 4 GB in size, we'd really only need to malloc() just the first 4 bytes.
3.  Trying to calculate the file size with fseek(...SEEK_END) is undefined and only correctly seeks to the end of the file in byte units on POSIX-conformant implementations.  A portable implementation of getting the file size is more difficult, tedious and unneeded for the task of just initializing the config.
4.  We don't need fread(), at least not yet.  As in the config file we're only working with the plain and simple UCHAR type, we can just loop through the file safely with fgetc() and secure error checks for each byte read.

Now the volume clamp I don't know about if I should have bothered doing.  I understand it's 0 max 100 min for some sort of Windows sound API (maybe both DirectSound and XAudio), but if the user wanted more precise audio control in some other API like OpenAL or SDL a `float` or `double` might have been neater, then it could be parsed to DirectSound-specific volume scales within the DirectSound code converting it to an integer between 0 and 100.  But YOLO, did it anyway.