### PR TITLE
DRAM, DMEM and IMEM should be in HLEMain.

### DIFF
--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -25,6 +25,10 @@ u32 t9, k0;
 u64 ProfileStartTimes[30];
 u64 ProfileTimes[30];
 
+u8 * DMEM;
+u8 * IMEM;
+u8 * DRAM;
+
 // Variables needed for ABI HLE
 u8 BufferSpace[0x10000];
 short hleMixerWorkArea[256];

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -125,11 +125,6 @@ u32 Dacrate = 0;
 // TODO: Instead of checking for an initialized state, we should default to a no-sound audio processing state and give a warning
 // Boolean audioIsInitialized = FALSE;
 
-//TODO: Do away with these from main.cpp.  They are only needed for HLE and available in AudioInfo
-u8 * DMEM;
-u8 * IMEM;
-u8 * DRAM;
-
 EXPORT Boolean CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 	if (snd != NULL)
 	{


### PR DESCRIPTION
Shouldn't this be sufficient?

I didn't remember the //TODO comment being added here, but I think I had only declared the new DRAM, DMEM and IMEM pointers inside main.cpp just because that was what had the zilmar spec function InitiateAudio, which was the best place to initiate them from the Audio_Info.RDRAM etc. longer names.

But yes, anything related to the RDRAM stuff should only be relevant to the HLE audio code.