### PR TITLE
Now compiles with -ansi.

### DIFF
--- a/AziAudio/AudioSpec.h
+++ b/AziAudio/AudioSpec.h
@@ -17,7 +17,9 @@ the plugin.
 
 #include "common.h"
 #include "my_types.h"
-//#include "Audio #1.1EXT.h"
+#if 0
+#include "Audio #1.1EXT.h"
+#endif
 
 #if defined(__cplusplus)
 extern "C" {
@@ -58,12 +60,12 @@ typedef struct {
 	HWND hwnd;
 	HINSTANCE hinst;
 
-	Boolean MemoryBswaped; // If this is set to TRUE, then the memory has been pre
-	                       //   bswap on a dword (32 bits) boundary 
-						   //	eg. the first 8 bytes are stored like this:
-	                       //        4 3 2 1   8 7 6 5
-	u8 * HEADER;	// This is the rom header (first 40h bytes of the rom
-					// This will be in the same memory format as the rest of the memory.
+	Boolean MemoryBswaped; /* If this is set to TRUE, then the memory has been pre
+	                        *   bswap on a dword (32 bits) boundary 
+				*	eg. the first 8 bytes are stored like this:
+				*	4 3 2 1   8 7 6 5 */
+	u8 * HEADER;    /* This is the rom header (first 40h bytes of the rom
+			 * This will be in the same memory format as the rest of the memory. */
 	u8 * RDRAM;
 	u8 * DMEM;
 	u8 * IMEM;
@@ -212,7 +214,7 @@ EXPORT void CALL AiCallBack(void);
 extern AUDIO_INFO AudioInfo;
 
 void HLEStart ();
-void ChangeABI (int type); // type 0 = SafeMode
+void ChangeABI (int type); /* type 0 = SafeMode */
 
 #define AI_STATUS_FIFO_FULL	0x80000000		/* Bit 31: full */
 #define AI_STATUS_DMA_BUSY	0x40000000		/* Bit 30: busy */

--- a/AziAudio/Mupen64plusHLE/Mupen64Support.c
+++ b/AziAudio/Mupen64plusHLE/Mupen64Support.c
@@ -11,7 +11,9 @@ void HleWarnMessage(void* user_defined, const char *message, ...)
 {
 	va_list args;
 	va_start(args, message);
-	//DebugMessage(M64MSG_WARNING, message, args);
+#if 0
+	DebugMessage(M64MSG_WARNING, message, args);
+#endif
 	va_end(args);
 
 	if (user_defined == NULL)
@@ -24,7 +26,9 @@ void HleVerboseMessage(void* user_defined, const char *message, ...)
 {
 	va_list args;
 	va_start(args, message);
-	//DebugMessage(M64MSG_VERBOSE, message, args);
+#if 0
+	DebugMessage(M64MSG_VERBOSE, message, args);
+#endif
 	va_end(args);
 
 	if (user_defined == NULL)

--- a/AziAudio/Mupen64plusHLE/common.h
+++ b/AziAudio/Mupen64plusHLE/common.h
@@ -34,6 +34,8 @@
 /* macro for inline keyword */
 #ifdef _MSC_VER
 #define inline __inline
+#elif defined(__GNUC_GNU_INLINE__)
+#define inline
 #endif
 
 /*

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -23,7 +23,9 @@
 #include <stdio.h>
 #include <assert.h>
 
-//#define ENABLEPROFILING
+#if 0
+#define ENABLEPROFILING
+#endif
 
 #if defined(_MSC_VER)
 #define SEH_SUPPORTED

--- a/Scripts/make.sh
+++ b/Scripts/make.sh
@@ -10,6 +10,7 @@ FLAGS_x86="\
  -masm=intel\
  -msse2\
  -mstackrealign\
+ -ansi\
 "
 C_FLAGS=$FLAGS_x86
 


### PR DESCRIPTION
I felt like doing some OCD clean-ups to the standards conformance of the code.

AziAudio compiles out of the box with the `-ansi` compiler switch in GCC.  This means that, when building the .c files, everything is backwards-compatible with the original C89 specification.  When building .cpp files, there's some other original version of the C++ specification being conformed to here.  (I don't know what it's called though because I really don't care about C++.)

The only exceptions were in zilmar's audio spec file and bsmiles audio code, which used the `inline` keyword (which is neither needed nor a part of the original C specs) and C++-style //comments.  Using C++-style comments in zilmar's audio spec header is fine when the AziAudio .cpp sources are including it, but when the bsmiles C code is including it we're kinda mixing different language rules.