### PR TITLE
Now compiles with -pedantic.

### DIFF
--- a/AziAudio/NoSoundDriver.h
+++ b/AziAudio/NoSoundDriver.h
@@ -18,10 +18,12 @@ NoSound Driver to demonstrate how to use the SoundDriver interface
 
 #if !defined(_WIN32) && !defined(_XBOX)
 typedef union _LARGE_INTEGER {
+#if defined(ANONYMOUS_STRUCTS_ARE_NOT_ALLOWED)
     struct {
         u32 LowPart;
         s32 HighPart;
-    };
+    }; /* ...but Microsoft uses them anyway. */
+#endif
     struct {
         u32 LowPart;
         s32 HighPart;

--- a/Scripts/make.sh
+++ b/Scripts/make.sh
@@ -10,6 +10,7 @@ FLAGS_x86="\
  -masm=intel\
  -msse2\
  -mstackrealign\
+ -pedantic\
 "
 C_FLAGS=$FLAGS_x86
 


### PR DESCRIPTION
So to get AziAudio to conform to standards and compile with `-ansi` required changing the bsmiles audio headers and zilmar's audio spec header.

To do likewise for being able to compile with `-pedantic` actually required only one single change...it was to code that I added myself as a quick hack to start trying to compile the NoSoundDriver class on Linux (which was using the LARGE_INTEGER win32 type, which I was trying to do a fast hack to emulate it on Linux in my experiments to get things to work.)

Once the NewAudio branch and other stuff by Azimer is merged in I will continue trying to get the plugin to run on Linux.  Getting everything ported now would be premature since some of the Win32 stuff is being replaced and/or under the deprecated legacy sound driver side, so in the meantime I'm just doing OCD warning fixes.

The only remaining thing is `-Wall` to enable all warnings...that emits a lot of warnings throughout the code so I'd better wait for this PR and the other one to be merged first.