### PR TITLE
fixed warning: redefinition of typedef 'Boolean' [-Wpedantic]

### DIFF
--- a/AziAudio/Mupen64plusHLE/common.h
+++ b/AziAudio/Mupen64plusHLE/common.h
@@ -38,24 +38,4 @@
 #define inline
 #endif
 
-/*
- * 2015.05.07 cxd4
- *
- * `bool' is not C programming, even if C99 granted the request.
- * Relevant C interpretation of Booleans is:  zero and nonzero.
- *
- * Past that, issues like allocation, packing or padding with Booleans are
- * more than controllable in correct C with or without type definitions,
- * especially in modern optimizing compilers.  The remaining issue is the
- * ability to say "true" and "false"--again external features irrelevant to
- * completeness of C implementation for the specific hardware architecture.
- */
-#if !defined(FALSE) && !defined(TRUE)
-enum {
-    FALSE = 0,
-    TRUE = 1
-};
-#endif
-typedef int Boolean;
-
 #endif

--- a/AziAudio/my_types.h
+++ b/AziAudio/my_types.h
@@ -443,8 +443,10 @@ typedef struct {
 typedef int Boolean;
 
 #if !defined(FALSE) && !defined(TRUE)
-#define FALSE           0
-#define TRUE            1
+enum {
+    FALSE = 0,
+    TRUE = 1
+};
 #endif
 
 #endif


### PR DESCRIPTION
I never realized this, but `Boolean` was already typedef'd in `AziAudio/my_types.h`, making the copy in `AziAudio/Mupen64plusHLE/common.h` unnecessary.

GCC only warned about this when both -ansi **and** -pedantic are passed together, so it took me until both PRs being merged by Azimer for the warning to finally show up.