### PR TITLE
Start compiling with all warnings enabled.

### DIFF
--- a/AziAudio/Mupen64plusHLE/memory.c
+++ b/AziAudio/Mupen64plusHLE/memory.c
@@ -20,8 +20,36 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include <string.h>
+#include <assert.h>
 
-#include "memory.h"
+#include "common.h"
+
+/*
+ * 2017.02.09:  helpers taken from "memory.h"
+ *
+ * We're not including "memory.h" itself because it's full of static function
+ * definitions--all but 3 of which are never used here--which causes tens of
+ * unused function warnings from unclean practice.  We could try for a more
+ * modular design, but the below 3 functions are straightforward to paste in.
+ */
+
+static uint8_t* pt_u8(const unsigned char* buffer, unsigned address)
+{
+    return (uint8_t *)(buffer + (address ^ ENDIAN_SWAP_BYTE));
+}
+
+static uint16_t* pt_u16(const unsigned char* buffer, unsigned address)
+{
+    assert((address & 1) == 0);
+    return (uint16_t *)(buffer + (address ^ ENDIAN_SWAP_HALF));
+}
+
+static uint32_t* pt_u32(const unsigned char* buffer, unsigned address)
+{
+    assert((address & 3) == 0);
+    return (uint32_t *)(buffer + address);
+}
+
 
 /* Global functions */
 void load_u8(uint8_t* dst, const unsigned char* buffer, unsigned address, size_t count)

--- a/AziAudio/Mupen64plusHLE/memory.h
+++ b/AziAudio/Mupen64plusHLE/memory.h
@@ -88,53 +88,13 @@ void store_u16(unsigned char* buffer, unsigned address, const uint16_t* src, siz
 void store_u32(unsigned char* buffer, unsigned address, const uint32_t* src, size_t count);
 
 
-/* convenient functions for DMEM access */
-static inline uint8_t* dmem_u8(struct hle_t* hle, uint16_t address)
-{
-    return pt_u8(hle->dmem, address & 0xfff);
-}
-
-static inline uint16_t* dmem_u16(struct hle_t* hle, uint16_t address)
-{
-    return pt_u16(hle->dmem, address & 0xfff);
-}
-
+/* convenient function for DMEM access */
 static inline uint32_t* dmem_u32(struct hle_t* hle, uint16_t address)
 {
     return pt_u32(hle->dmem, address & 0xfff);
 }
 
-static inline void dmem_load_u8(struct hle_t* hle, uint8_t* dst, uint16_t address, size_t count)
-{
-    load_u8(dst, hle->dmem, address & 0xfff, count);
-}
-
-static inline void dmem_load_u16(struct hle_t* hle, uint16_t* dst, uint16_t address, size_t count)
-{
-    load_u16(dst, hle->dmem, address & 0xfff, count);
-}
-
-static inline void dmem_load_u32(struct hle_t* hle, uint32_t* dst, uint16_t address, size_t count)
-{
-    load_u32(dst, hle->dmem, address & 0xfff, count);
-}
-
-static inline void dmem_store_u8(struct hle_t* hle, const uint8_t* src, uint16_t address, size_t count)
-{
-    store_u8(hle->dmem, address & 0xfff, src, count);
-}
-
-static inline void dmem_store_u16(struct hle_t* hle, const uint16_t* src, uint16_t address, size_t count)
-{
-    store_u16(hle->dmem, address & 0xfff, src, count);
-}
-
-static inline void dmem_store_u32(struct hle_t* hle, const uint32_t* src, uint16_t address, size_t count)
-{
-    store_u32(hle->dmem, address & 0xfff, src, count);
-}
-
-/* convenient functions DRAM access */
+/* convenient functions for DRAM access */
 static inline uint8_t* dram_u8(struct hle_t* hle, uint32_t address)
 {
     return pt_u8(hle->dram, address & 0xffffff);
@@ -165,19 +125,9 @@ static inline void dram_load_u32(struct hle_t* hle, uint32_t* dst, uint32_t addr
     load_u32(dst, hle->dram, address & 0xffffff, count);
 }
 
-static inline void dram_store_u8(struct hle_t* hle, const uint8_t* src, uint32_t address, size_t count)
-{
-    store_u8(hle->dram, address & 0xffffff, src, count);
-}
-
 static inline void dram_store_u16(struct hle_t* hle, const uint16_t* src, uint32_t address, size_t count)
 {
     store_u16(hle->dram, address & 0xffffff, src, count);
-}
-
-static inline void dram_store_u32(struct hle_t* hle, const uint32_t* src, uint32_t address, size_t count)
-{
-    store_u32(hle->dram, address & 0xffffff, src, count);
 }
 
 #endif

--- a/Scripts/make.sh
+++ b/Scripts/make.sh
@@ -12,6 +12,7 @@ FLAGS_x86="\
  -mstackrealign\
  -ansi\
  -pedantic\
+ -Wall\
 "
 C_FLAGS=$FLAGS_x86
 


### PR DESCRIPTION
Adding `-Wall` has introduced many warnings in the compile output.  A few of them look like they could be bugs...but right now in this PR I am only focusing on the most tedious, repetitive warning:

"unused function".  It's due to bsmiles' memory.h making static definitions of functions from inside the header.  Any .c file that includes memory.h must use all of those functions or else ignore code cleanliness warnings, which I don't really see a cause for bypassing.

Once I can get the spamming of these warnings out of the way, I can focus on the less trivial ones.
```
In file included from ./../AziAudio/Mupen64plusHLE/memory.c:24:0:
./../AziAudio/Mupen64plusHLE/memory.h:77:25: note: previous definition of 'pt_u32' was here
 static inline uint32_t* pt_u32(const unsigned char* buffer, unsigned address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:60:28: warning: 'align' defined but not used [-Wunused-function]
 static inline unsigned int align(unsigned int x, unsigned amount)
                            ^
./../AziAudio/Mupen64plusHLE/memory.h:92:24: warning: 'dmem_u8' defined but not used [-Wunused-function]
 static inline uint8_t* dmem_u8(struct hle_t* hle, uint16_t address)
                        ^
./../AziAudio/Mupen64plusHLE/memory.h:97:25: warning: 'dmem_u16' defined but not used [-Wunused-function]
 static inline uint16_t* dmem_u16(struct hle_t* hle, uint16_t address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:102:25: warning: 'dmem_u32' defined but not used [-Wunused-function]
 static inline uint32_t* dmem_u32(struct hle_t* hle, uint16_t address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:107:20: warning: 'dmem_load_u8' defined but not used [-Wunused-function]
 static inline void dmem_load_u8(struct hle_t* hle, uint8_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:112:20: warning: 'dmem_load_u16' defined but not used [-Wunused-function]
 static inline void dmem_load_u16(struct hle_t* hle, uint16_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:117:20: warning: 'dmem_load_u32' defined but not used [-Wunused-function]
 static inline void dmem_load_u32(struct hle_t* hle, uint32_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:122:20: warning: 'dmem_store_u8' defined but not used [-Wunused-function]
 static inline void dmem_store_u8(struct hle_t* hle, const uint8_t* src, uint16_t address, size_t co
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:127:20: warning: 'dmem_store_u16' defined but not used [-Wunused-function]
 static inline void dmem_store_u16(struct hle_t* hle, const uint16_t* src, uint16_t address, size_t 
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:132:20: warning: 'dmem_store_u32' defined but not used [-Wunused-function]
 static inline void dmem_store_u32(struct hle_t* hle, const uint32_t* src, uint16_t address, size_t 
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:138:24: warning: 'dram_u8' defined but not used [-Wunused-function]
 static inline uint8_t* dram_u8(struct hle_t* hle, uint32_t address)
                        ^
./../AziAudio/Mupen64plusHLE/memory.h:143:25: warning: 'dram_u16' defined but not used [-Wunused-function]
 static inline uint16_t* dram_u16(struct hle_t* hle, uint32_t address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:148:25: warning: 'dram_u32' defined but not used [-Wunused-function]
 static inline uint32_t* dram_u32(struct hle_t* hle, uint32_t address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:153:20: warning: 'dram_load_u8' defined but not used [-Wunused-function]
 static inline void dram_load_u8(struct hle_t* hle, uint8_t* dst, uint32_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:158:20: warning: 'dram_load_u16' defined but not used [-Wunused-function]
 static inline void dram_load_u16(struct hle_t* hle, uint16_t* dst, uint32_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:163:20: warning: 'dram_load_u32' defined but not used [-Wunused-function]
 static inline void dram_load_u32(struct hle_t* hle, uint32_t* dst, uint32_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:168:20: warning: 'dram_store_u8' defined but not used [-Wunused-function]
 static inline void dram_store_u8(struct hle_t* hle, const uint8_t* src, uint32_t address, size_t co
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:173:20: warning: 'dram_store_u16' defined but not used [-Wunused-function]
 static inline void dram_store_u16(struct hle_t* hle, const uint16_t* src, uint32_t address, size_t 
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:178:20: warning: 'dram_store_u32' defined but not used [-Wunused-function]
 static inline void dram_store_u32(struct hle_t* hle, const uint32_t* src, uint32_t address, size_t 
                    ^
```

```
In file included from ./../AziAudio/Mupen64plusHLE/musyx.c:31:0:
./../AziAudio/Mupen64plusHLE/memory.h:92:24: warning: 'dmem_u8' defined but not used [-Wunused-function]
 static inline uint8_t* dmem_u8(struct hle_t* hle, uint16_t address)
                        ^
./../AziAudio/Mupen64plusHLE/memory.h:97:25: warning: 'dmem_u16' defined but not used [-Wunused-function]
 static inline uint16_t* dmem_u16(struct hle_t* hle, uint16_t address)
                         ^
./../AziAudio/Mupen64plusHLE/memory.h:107:20: warning: 'dmem_load_u8' defined but not used [-Wunused-function]
 static inline void dmem_load_u8(struct hle_t* hle, uint8_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:112:20: warning: 'dmem_load_u16' defined but not used [-Wunused-function]
 static inline void dmem_load_u16(struct hle_t* hle, uint16_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:117:20: warning: 'dmem_load_u32' defined but not used [-Wunused-function]
 static inline void dmem_load_u32(struct hle_t* hle, uint32_t* dst, uint16_t address, size_t count)
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:122:20: warning: 'dmem_store_u8' defined but not used [-Wunused-function]
 static inline void dmem_store_u8(struct hle_t* hle, const uint8_t* src, uint16_t address, size_t co
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:127:20: warning: 'dmem_store_u16' defined but not used [-Wunused-function]
 static inline void dmem_store_u16(struct hle_t* hle, const uint16_t* src, uint16_t address, size_t 
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:132:20: warning: 'dmem_store_u32' defined but not used [-Wunused-function]
 static inline void dmem_store_u32(struct hle_t* hle, const uint32_t* src, uint16_t address, size_t 
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:168:20: warning: 'dram_store_u8' defined but not used [-Wunused-function]
 static inline void dram_store_u8(struct hle_t* hle, const uint8_t* src, uint32_t address, size_t co
                    ^
./../AziAudio/Mupen64plusHLE/memory.h:178:20: warning: 'dram_store_u32' defined but not used [-Wunused-function]
 static inline void dram_store_u32(struct hle_t* hle, const uint32_t* src, uint32_t address, size_t 
                    ^
```