### PR TITLE
warning: suggest explicit braces to avoid ambiguous 'else' [-Wparentheses]

### DIFF
--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -306,11 +306,12 @@ void ADPCM2() { // Verified to be 100% Accurate...
 
 	memset(out, 0, 32);
 
-	if (!(Flags & 0x1))
+	if (!(Flags & 0x1)) {
 		if (Flags & 0x2)
 			memcpy(out, &DRAM[loopval], 32);
 		else
 			memcpy(out, &DRAM[Address], 32);
+	}
 	if (Flags & 0x4) { // Tricky lil Zelda MM and ABI2!!! hahaha I know your secrets! :DDD
 		srange = 0xE;
 		inpinc = 0x5;
@@ -420,11 +421,12 @@ void ADPCM3() { // Verified to be 100% Accurate...
 
 	memset(out, 0, 32);
 
-	if (!(Flags & 0x1))
+	if (!(Flags & 0x1)) {
 		if (Flags & 0x2)
 			memcpy(out, &DRAM[loopval], 32);
 		else
 			memcpy(out, &DRAM[Address], 32);
+	}
 
 	s16 l1 = out[15];
 	s16 l2 = out[14];


### PR DESCRIPTION
```
./../AziAudio/ABI_Adpcm.cpp: In function 'void ADPCM2()':
./../AziAudio/ABI_Adpcm.cpp:309:5: warning: suggest explicit braces to avoid ambiguous 'else' [-Wparentheses]
  if (!(Flags & 0x1))
     ^
./../AziAudio/ABI_Adpcm.cpp:302:5: warning: variable 'inpinc' set but not used [-Wunused-but-set-variable]
  u8 inpinc;
     ^
./../AziAudio/ABI_Adpcm.cpp: In function 'void ADPCM3()':
./../AziAudio/ABI_Adpcm.cpp:423:5: warning: suggest explicit braces to avoid ambiguous 'else' [-Wparentheses]
  if (!(Flags & 0x1))
     ^
```