### PR TITLE
warning: logical NOT applied to left side only [-Wlogical-not-parentheses]

### DIFF
--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -119,7 +119,7 @@ void SoundDriver::AI_Startup()
 #ifdef LEGACY_SOUND_DRIVER	
 	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
-	m_audioIsInitialized = (Initialize() != FALSE) ? true : false;
+	m_audioIsInitialized = (Initialize() != FALSE);
 	if (m_audioIsInitialized == true) SetVolume(configVolume);
 #else
 	Initialize();

--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -119,7 +119,7 @@ void SoundDriver::AI_Startup()
 #ifdef LEGACY_SOUND_DRIVER	
 	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
-	m_audioIsInitialized = (!Initialize() == TRUE);
+	m_audioIsInitialized = (Initialize() != FALSE) ? true : false;
 	if (m_audioIsInitialized == true) SetVolume(configVolume);
 #else
 	Initialize();

--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -119,7 +119,7 @@ void SoundDriver::AI_Startup()
 #ifdef LEGACY_SOUND_DRIVER	
 	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
-	m_audioIsInitialized = (Initialize() != FALSE);
+	m_audioIsInitialized = (Initialize() == FALSE);
 	if (m_audioIsInitialized == true) SetVolume(configVolume);
 #else
 	Initialize();


### PR DESCRIPTION
```
./../AziAudio/SoundDriver.cpp: In member function 'void SoundDriver::AI_ResetAudio()':
./../AziAudio/SoundDriver.cpp:170:40: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
  m_audioIsInitialized = (!Initialize() == TRUE);
                                        ^
```