### PR TITLE
unused variable warnings

### DIFF
--- a/AziAudio/NoSoundDriver.cpp
+++ b/AziAudio/NoSoundDriver.cpp
@@ -71,9 +71,9 @@ void NoSoundDriver::StartAudio()
 
 void NoSoundDriver::SetFrequency(u32 Frequency)
 {
+#ifdef _WIN32
 	int SamplesPerSecond = Frequency; // 16 bit * stereo
 
-#ifdef _WIN32
 	// Must determine the number of Counter units per Sample
 	QueryPerformanceFrequency(&perfFreq); // Counters per Second
 

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -32,7 +32,7 @@
 #endif
 
 #if !defined(_WIN32) && !defined(_XBOX)
-#define UNREFERENCED_PARAMETER(msg)     msg
+#define UNREFERENCED_PARAMETER(msg)
 #endif
 
 class SoundDriver


### PR DESCRIPTION
...and this should be the last of them.

Everything compiles now under -Wall with no warnings at all except only for two remaining warnings I won't try to fix by myself.  https://github.com/Azimer/AziAudio/issues/171 and https://github.com/Azimer/AziAudio/issues/172

Warnings fixed in this PR:
```
In file included from ./../AziAudio/SDLSoundDriver.h:14:0,
                 from ./../AziAudio/main.cpp:20:
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::AiUpdate(Boolean)':
./../AziAudio/SoundDriver.h:58:68: warning: statement has no effect [-Wunused-value]
  virtual void AiUpdate(Boolean Wait) { UNREFERENCED_PARAMETER(Wait); }; // Optional
                                                                    ^
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::SetVolume(u32)':
./../AziAudio/SoundDriver.h:84:69: warning: statement has no effect [-Wunused-value]
  virtual void SetVolume(u32 volume) { UNREFERENCED_PARAMETER(volume); }; // We could potentially do
                                                                     ^
In file included from ./../AziAudio/SoundDriver.cpp:12:0:
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::AiUpdate(Boolean)':
./../AziAudio/SoundDriver.h:58:68: warning: statement has no effect [-Wunused-value]
  virtual void AiUpdate(Boolean Wait) { UNREFERENCED_PARAMETER(Wait); }; // Optional
                                                                    ^
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::SetVolume(u32)':
./../AziAudio/SoundDriver.h:84:69: warning: statement has no effect [-Wunused-value]
  virtual void SetVolume(u32 volume) { UNREFERENCED_PARAMETER(volume); }; // We could potentially do
                                                                     ^
In file included from ./../AziAudio/NoSoundDriver.h:17:0,
                 from ./../AziAudio/NoSoundDriver.cpp:5:
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::AiUpdate(Boolean)':
./../AziAudio/SoundDriver.h:58:68: warning: statement has no effect [-Wunused-value]
  virtual void AiUpdate(Boolean Wait) { UNREFERENCED_PARAMETER(Wait); }; // Optional
                                                                    ^
./../AziAudio/SoundDriver.h: In member function 'virtual void SoundDriver::SetVolume(u32)':
./../AziAudio/SoundDriver.h:84:69: warning: statement has no effect [-Wunused-value]
  virtual void SetVolume(u32 volume) { UNREFERENCED_PARAMETER(volume); }; // We could potentially do
                                                                     ^
./../AziAudio/NoSoundDriver.cpp: In member function 'virtual void NoSoundDriver::SetFrequency(u32)':
./../AziAudio/NoSoundDriver.cpp:74:6: warning: unused variable 'SamplesPerSecond' [-Wunused-variable]
  int SamplesPerSecond = Frequency; // 16 bit * stereo
      ^
```