### PR TITLE
replicated order-of-operations warning fix in AI_ResetAudio()

### DIFF
--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -167,7 +167,7 @@ void SoundDriver::AI_ResetAudio()
 	StopAudio();
 	if (m_audioIsInitialized == true) DeInitialize();
 	m_audioIsInitialized = false;
-	m_audioIsInitialized = (!Initialize() == TRUE);
+	m_audioIsInitialized = (Initialize() == FALSE);
 	StartAudio();
 }
 


### PR DESCRIPTION
This is just a continuity of https://github.com/Azimer/AziAudio/pull/168 .

Not sure what happened.  This looks like the warning that was originally reported, but I fixed it for the copy of the call under LEGACY_SOUND_DRIVER.  There were actually two cases of (!Initialize() == TRUE) throughout the file; they should both be fixed now.