### PR TITLE
included stddef.h to always define size_t

### DIFF
--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -23,6 +23,8 @@
 #ifndef _COMMON_DOT_H_
 #define _COMMON_DOT_H_
 
+#include <stddef.h> // size_t definition
+
 #if defined (_XBOX)
 #include <xtl.h>
 #include "../3rd Party/XBox/xbox_depp.h"


### PR DESCRIPTION
```
In file included from ./../AziAudio/audiohle.h:12:0,
                 from ./../AziAudio/ABI1.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/audiohle.h:83,
                 from ./../AziAudio/ABI1.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/audiohle.h:12:0,
                 from ./../AziAudio/ABI2.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/audiohle.h:83,
                 from ./../AziAudio/ABI2.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/audiohle.h:12:0,
                 from ./../AziAudio/ABI3.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/audiohle.h:83,
                 from ./../AziAudio/ABI3.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/audiohle.h:12:0,
                 from ./../AziAudio/ABI_MixerInterleave.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/audiohle.h:83,
                 from ./../AziAudio/ABI_MixerInterleave.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/audiohle.h:12:0,
                 from ./../AziAudio/ABI_Resample.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/audiohle.h:83,
                 from ./../AziAudio/ABI_Resample.cpp:12:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/main.cpp:12:0:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/AudioSpec.h:18:0,
                 from ./../AziAudio/main.cpp:13:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
In file included from ./../AziAudio/SoundDriverInterface.h:3:0,
                 from ./../AziAudio/main.cpp:15:
./../AziAudio/common.h:168:35: error: 'size_t' has not been declared
 extern int safe_strcpy(char* dst, size_t limit, const char* src);
                                   ^
```