### PR TITLE
included string.h to declare memcpy() and strcpy()

### DIFF
--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -18,6 +18,7 @@
 #include "audiohle.h"
 //#include "rsp/rsp.h"
 
+#include <string.h> // memcpy(), strcpy()
 #include <stdio.h> // needed for configuration
 
 #ifdef USE_PRINTF


### PR DESCRIPTION
```
./../AziAudio/main.cpp:133:52: error: 'memcpy' was not declared in this scope
  memcpy(&AudioInfo, &Audio_Info, sizeof(AUDIO_INFO));
                                                    ^
./../AziAudio/main.cpp:144:52: error: 'strcpy' was not declared in this scope
  strcpy(Configuration::configAudioLogFolder, "D:\\");
                                                    ^
./../AziAudio/main.cpp: In function 'int safe_strcpy(char*, size_t, const char*)':
./../AziAudio/main.cpp:431:23: error: 'strlen' was not declared in this scope
     bytes = strlen(src) + 1; /* strlen("abc") + 1 == 4 bytes */
                       ^
./../AziAudio/main.cpp:438:27: error: 'memcpy' was not declared in this scope
     memcpy(dst, src, bytes);
                           ^
```