### PR TITLE
moved UNREFERENCED_PARAMETER workaround ifndef WIN32

### DIFF
--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -29,10 +29,6 @@
 #define SND_IS_NOT_EMPTY 0x4000000
 #define SND_IS_FULL		 0x8000000
 
-#if !defined(_WIN32) && !defined(_XBOX)
-#define UNREFERENCED_PARAMETER(msg)
-#endif
-
 class SoundDriver :
 	public SoundDriverInterface
 {

--- a/AziAudio/SoundDriverLegacy.h
+++ b/AziAudio/SoundDriverLegacy.h
@@ -29,10 +29,6 @@
 #define SND_IS_NOT_EMPTY 0x4000000
 #define SND_IS_FULL		 0x8000000
 
-#if !defined(_WIN32) && !defined(_XBOX)
-#define UNREFERENCED_PARAMETER(msg)
-#endif
-
 class SoundDriverLegacy :
 	public SoundDriverInterface
 {

--- a/AziAudio/my_types.h
+++ b/AziAudio/my_types.h
@@ -449,4 +449,10 @@ enum {
 };
 #endif
 
+#ifndef UNREFERENCED_PARAMETER
+#if !defined(_WIN32) && !defined(_XBOX)
+#define UNREFERENCED_PARAMETER(msg)
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
Something about recent branches merged into master has removed the includes for these defines.