### PR TITLE
[XA2] Fix stutter/stalling/crackling with smaller buffer?

### DIFF
--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -234,7 +234,6 @@ DWORD WINAPI XAudio2SoundDriver::AudioThreadProc(LPVOID lpParameter)
 				g_source->GetState(&xvs);
 			}
 		}
-		Sleep(1);
 	}
 	return 0;
 }


### PR DESCRIPTION
Sleep(1) here causes emulation to stall.  I removed it and I no longer need a bigger buffer for musyx games.  I changed bufferFPS to:
	configBufferLevel = 2;
	configBufferFPS = 96;
	configBackendFPS = 96;
Which seems slightly better than 90 here.
Also with Sleep(1) here, Body Harvest stalled the VI's to 40+ in intro (in places), and audio got ahead of gfx badly (with latest WIP GLideN64).  Body Harvest still crackles bad with FAT, but is now perfect with FAT off.

TWINE, RE2, WDC and Top Gear Rally are all good with FAT on or off.  PBO and AI on in AziAudio.  Though some games PBO don't sync to 60 with framelimiter off, Twisted Edge, WDC, Top Gear Rally, Banjo Kazooie + Tooie, Goldeneye, Perfect Dark, Conker's Bad Fur Day, Winback, BattleTanx, Diddy Kong Racing and Donkey Kong 64 are a few games I noticed.  Most other games do sync to 60 with framelimiter off and PBO on.