### PR TITLE
strcpy() not declared in this scope

### DIFF
--- a/AziAudio/Configuration.h
+++ b/AziAudio/Configuration.h
@@ -5,6 +5,9 @@
 #include <Windows.h>
 #endif
 
+/* strcpy() */
+#include <string.h>
+
 class Configuration
 {
 protected:


### PR DESCRIPTION
```
In file included from ./../AziAudio/SoundDriverInterface.h:4:0,
                 from ./../AziAudio/main.cpp:15:
./../AziAudio/Configuration.h: In static member function 'static char* Configuration::getAudioLogFolder()':
./../AziAudio/Configuration.h:41:38: error: 'strcpy' was not declared in this scope
   strcpy(retVal, configAudioLogFolder);
                                      ^
./../AziAudio/Configuration.h: In static member function 'static char* Configuration::getDevice()':
./../AziAudio/Configuration.h:46:30: error: 'strcpy' was not declared in this scope
   strcpy(retVal, configDevice);
                              ^

In file included from ./../AziAudio/SoundDriverInterface.h:4:0,
                 from ./../AziAudio/SoundDriverFactory.h:2,
                 from ./../AziAudio/SoundDriverFactory.cpp:2:
# same two errors with strcpy()

In file included from ./../AziAudio/SoundDriverInterface.h:4:0,
                 from ./../AziAudio/SoundDriverInterface.cpp:1:
# same two errors with strcpy()
```