### PR TITLE
Keep binary files resource.res and vc90.idb out.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ dlldata.c
 *_i.c
 *_p.c
 *_i.h
+*.idb
 *.ilk
 *.meta
 *.obj
@@ -60,6 +61,7 @@ dlldata.c
 *.pdb
 *.pgc
 *.pgd
+*.res
 *.rsp
 *.sbr
 *.tlb


### PR DESCRIPTION
These files popped up in my working Git stage list when using WINE console to cross-compile the Windows build of AziAudio using the Windows DDK on Linux.