### PR TITLE
Backend failover

### DIFF
--- a/AziAudio/ABI1.cpp
+++ b/AziAudio/ABI1.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI2.cpp
+++ b/AziAudio/ABI2.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI3.cpp
+++ b/AziAudio/ABI3.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI3mp3.cpp
+++ b/AziAudio/ABI3mp3.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_Adpcm.cpp
+++ b/AziAudio/ABI_Adpcm.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_Buffers.cpp
+++ b/AziAudio/ABI_Buffers.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_Envmixer.cpp
+++ b/AziAudio/ABI_Envmixer.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_Filters.cpp
+++ b/AziAudio/ABI_Filters.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_MixerInterleave.cpp
+++ b/AziAudio/ABI_MixerInterleave.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/ABI_Resample.cpp
+++ b/AziAudio/ABI_Resample.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/Configuration.cpp
+++ b/AziAudio/Configuration.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/Configuration.cpp
+++ b/AziAudio/Configuration.cpp
@@ -161,6 +161,7 @@ void Configuration::LoadDefaults()
 	setBackendFPS(90);
 	setDisallowSleepDS8(false);
 	setDisallowSleepXA2(false);
+	setResTimer(false);
 	LoadSettings();
 }
 #ifdef _WIN32

--- a/AziAudio/Configuration.cpp
+++ b/AziAudio/Configuration.cpp
@@ -148,7 +148,7 @@ void Configuration::LoadDefaults()
 	}
 #endif
 	configVolume = 0; /* 0:  max volume; 100:  min volume */
-	EnumDriverCount = SoundDriverFactory::EnumDrivers(EnumDriverType, 10);
+	EnumDriverCount = SoundDriverFactory::EnumDrivers(EnumDriverType, 10); // TODO: This needs to be fixed.  10 is an arbitrary number which doesn't meet the 20 set in MAX_FACTORY_DRIVERS
 	setDriver(SoundDriverFactory::DefaultDriver());	
 	setAIEmulation(true);
 	setSyncAudio(true);

--- a/AziAudio/Configuration.h
+++ b/AziAudio/Configuration.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/Configuration.h
+++ b/AziAudio/Configuration.h
@@ -50,6 +50,7 @@ protected:
 	static void setBackendFPS(unsigned long value) { currentSettings.configBackendFPS = value; }
 	static void setDisallowSleepXA2(bool value) { currentSettings.configDisallowSleepXA2 = value; };
 	static void setDisallowSleepDS8(bool value) { currentSettings.configDisallowSleepDS8 = value; };
+	static void setResTimer(bool value) { currentSettings.configResTimer = value; };
 
 	static void ResetAdvancedPage(HWND hDlg);
 
@@ -80,4 +81,5 @@ public:
 	static unsigned long getBackendFPS() { return currentSettings.configBackendFPS; }
 	static bool getDisallowSleepXA2() { return currentSettings.configDisallowSleepXA2; };
 	static bool getDisallowSleepDS8() { return currentSettings.configDisallowSleepDS8; };
+	static bool getResTimer() { return currentSettings.configResTimer; };
 };

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
@@ -44,7 +44,22 @@ static DWORD interruptcnt = 0;
 
 bool DirectSoundDriver::ValidateDriver()
 {
-	return true;
+	bool retVal = false;
+	const GUID CLSID_DirectSound8_Test = { 0x3901cc3f, 0x84b5, 0x4fa4, 0xba, 0x35, 0xaa, 0x81, 0x72, 0xb8, 0xa0, 0x9b };
+	const GUID IID_IDirectSound8_Test = { 0xC50A7E93, 0xF395, 0x4834, 0x9E, 0xF6, 0x7F, 0xA9, 0x9D, 0xE5, 0x09, 0x66 };
+
+	/* Validate an DirectSound8 object will initialize */
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	IUnknown* obj;
+	HRESULT hr = CoCreateInstance(CLSID_DirectSound8_Test,
+		NULL, CLSCTX_INPROC_SERVER, IID_IDirectSound8_Test, (void**)&obj);
+	if (SUCCEEDED(hr))
+	{
+		obj->Release();
+		retVal = true;
+	}
+	CoUninitialize();
+	return retVal;
 }
 
 DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
@@ -388,7 +403,7 @@ void DirectSoundDriver::SetFrequency(u32 Frequency2) {
 	// 
 	StopAudio();
 
-	sLOCK_SIZE = (u32)((Frequency / Configuration::getBufferFPS())) * 4; //(Frequency / 80) * 4;// 0x600;// (22050 / 30) * 4;// 0x4000;// (Frequency / 60) * 4;
+	sLOCK_SIZE = (u32)((Frequency / Configuration::getBackendFPS())) * 4; //(Frequency / 80) * 4;// 0x600;// (22050 / 30) * 4;// 0x4000;// (Frequency / 60) * 4;
 	SampleRate = Frequency;
 	SegmentSize = 0; // Trash it... we need to redo the Frequency anyway...
 	SetSegmentSize(LOCK_SIZE);

--- a/AziAudio/DirectSoundDriver.cpp
+++ b/AziAudio/DirectSoundDriver.cpp
@@ -17,7 +17,9 @@
 //#include "WaveOut.h"
 #include "SoundDriverFactory.h"
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_DS8, DirectSoundDriver::CreateSoundDriver, "DirectSound 8 Driver", 6);
+bool DirectSoundDriver::ClassRegistered = DirectSoundDriver::ValidateDriver() ?
+			SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_DS8, DirectSoundDriver::CreateSoundDriver, "DirectSound 8 Driver", 6) :
+			false;
 
 // TODO: Clean this up a bit...
 static DWORD sLOCK_SIZE;
@@ -40,6 +42,10 @@ static DWORD interruptcnt = 0;
 
 //WaveOut test;
 
+bool DirectSoundDriver::ValidateDriver()
+{
+	return true;
+}
 
 DWORD WINAPI AudioThreadProc(DirectSoundDriver *ac) {
 	DWORD dwStatus;

--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/DirectSoundDriver.h
+++ b/AziAudio/DirectSoundDriver.h
@@ -80,4 +80,7 @@ public:
 	void SetVolume(u32 volume);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new DirectSoundDriver(); }
+	static bool ValidateDriver();
+private:
+	static bool ClassRegistered;
 };

--- a/AziAudio/DirectSoundDriverLegacy.cpp
+++ b/AziAudio/DirectSoundDriverLegacy.cpp
@@ -17,7 +17,9 @@
 //#include "WaveOut.h"
 #include "SoundDriverFactory.h"
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_DS8L, DirectSoundDriverLegacy::CreateSoundDriver, "DirectSound 8 Legacy Driver", 5);
+bool DirectSoundDriverLegacy::ClassRegistered = DirectSoundDriverLegacy::ValidateDriver() ?
+			SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_DS8L, DirectSoundDriverLegacy::CreateSoundDriver, "DirectSound 8 Legacy Driver", 5) :
+			false;
 
 // TODO: Clean this up a bit...
 
@@ -41,6 +43,11 @@ static DWORD interruptcnt = 0;
 
 //WaveOut test;
 #define STREAM_DMA
+
+bool DirectSoundDriverLegacy::ValidateDriver()
+{
+	return true;
+}
 
 // Fills up a buffer and remixes the audio (Streaming version)
 #ifdef STREAM_DMA // Streaming Version

--- a/AziAudio/DirectSoundDriverLegacy.h
+++ b/AziAudio/DirectSoundDriverLegacy.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/DirectSoundDriverLegacy.h
+++ b/AziAudio/DirectSoundDriverLegacy.h
@@ -84,5 +84,8 @@ public:
 	void SetVolume(u32 volume);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new DirectSoundDriverLegacy(); }
+	static bool ValidateDriver();
+private:
+	static bool ClassRegistered;
 
 };

--- a/AziAudio/HLEMain.cpp
+++ b/AziAudio/HLEMain.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/Mupen64plusHLE/Mupen64Support.c
+++ b/AziAudio/Mupen64plusHLE/Mupen64Support.c
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/arithmetics.h
+++ b/AziAudio/Mupen64plusHLE/arithmetics.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/audio.c
+++ b/AziAudio/Mupen64plusHLE/audio.c
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/audio.h
+++ b/AziAudio/Mupen64plusHLE/audio.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/common.h
+++ b/AziAudio/Mupen64plusHLE/common.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/hle.h
+++ b/AziAudio/Mupen64plusHLE/hle.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/hle_external.h
+++ b/AziAudio/Mupen64plusHLE/hle_external.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/hle_internal.h
+++ b/AziAudio/Mupen64plusHLE/hle_internal.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/memory.c
+++ b/AziAudio/Mupen64plusHLE/memory.c
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/memory.h
+++ b/AziAudio/Mupen64plusHLE/memory.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/musyx.c
+++ b/AziAudio/Mupen64plusHLE/musyx.c
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/Mupen64plusHLE/ucodes.h
+++ b/AziAudio/Mupen64plusHLE/ucodes.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 *                                                                           *

--- a/AziAudio/NoSoundDriver.cpp
+++ b/AziAudio/NoSoundDriver.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/NoSoundDriver.cpp
+++ b/AziAudio/NoSoundDriver.cpp
@@ -17,7 +17,15 @@
 #include <unistd.h>
 #endif
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_NOSOUND, NoSoundDriver::CreateSoundDriver, "No Sound Driver", 0);
+bool NoSoundDriver::ClassRegistered = NoSoundDriver::ValidateDriver() ?
+		SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_NOSOUND, NoSoundDriver::CreateSoundDriver, "No Sound Driver", 0) :
+		false;
+
+bool NoSoundDriver::ValidateDriver()
+{
+	// No Sound should always be an option.  The only issue is if GetTickCount isn't supported or something similar
+	return true;
+}
 
 Boolean NoSoundDriver::Initialize()
 {

--- a/AziAudio/NoSoundDriver.h
+++ b/AziAudio/NoSoundDriver.h
@@ -50,7 +50,7 @@ public:
 	void SetFrequency(u32 Frequency);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new NoSoundDriver(); }
-
+	static bool ValidateDriver();
 
 protected:
 	bool dllInitialized;
@@ -62,4 +62,7 @@ protected:
 	*/
 	bool isPlaying;
 	u32 lastTick;
+
+private:
+	static bool ClassRegistered;
 };

--- a/AziAudio/NoSoundDriver.h
+++ b/AziAudio/NoSoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/Settings.h
+++ b/AziAudio/Settings.h
@@ -14,6 +14,7 @@ public:
 	bool configDisallowSleepXA2;
 	bool configDisallowSleepDS8;
 	unsigned long configBitRate;
+	bool configResTimer;
 
 	u16 CartID;
 	char CartName[21];

--- a/AziAudio/SoundDriver.cpp
+++ b/AziAudio/SoundDriver.cpp
@@ -26,11 +26,11 @@ void SoundDriver::AI_LenChanged(u8 *start, u32 length)
 	// Bleed off some of this buffer to smooth out audio
 	if ((length < m_MaxBufferSize) && (Configuration::getSyncAudio() == true) /*&& m_AI_DMAPrimaryBytes > 0*/)
 	{
-		if (m_MaxBufferSize == m_BufferRemaining)
+		if (m_AI_DMASecondaryBuffer > 0)
 		{
 			DEBUG_OUTPUT("B"); // Debug that we overflowed (shouldn't happen with locked FPS)
 		}
-		while (m_MaxBufferSize < (m_BufferRemaining + length))
+		while (m_AI_DMASecondaryBuffer > 0)
 		{
 #ifdef _WIN32
 			Sleep(1);

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -55,6 +55,7 @@ public:
 protected:
 	// Temporary (to allow for incremental development)
 	bool m_audioIsInitialized;
+	bool m_isValid;
 
 	// Mutex Handle
 #ifdef _WIN32

--- a/AziAudio/SoundDriver.h
+++ b/AziAudio/SoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverFactory.cpp
+++ b/AziAudio/SoundDriverFactory.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverFactory.cpp
+++ b/AziAudio/SoundDriverFactory.cpp
@@ -65,6 +65,44 @@ SoundDriverType SoundDriverFactory::DefaultDriver()
 	return retVal;
 }
 
+SoundDriverInterface* SoundDriverFactory::FailoverDriver()
+{
+	SoundDriverType drivers[MAX_FACTORY_DRIVERS];
+	int index[MAX_FACTORY_DRIVERS];
+	bool sorted = false;
+
+	// Copy the drivers
+	for (int x = 0; x < FactoryNextSlot; x++)
+	{
+		drivers[x] = FactoryDrivers[x].DriverType;
+		index[x] = x;
+	}
+
+	// Sort on priority
+	while (sorted == false)
+	{
+		sorted = true;
+		for (int x = 0; x < FactoryNextSlot-1; x++)
+		{
+			if (FactoryDrivers[index[x]].Priority <
+				FactoryDrivers[index[x+1]].Priority)
+			{
+				int i;
+				i = index[x];
+				index[x] = index[x + 1];
+				index[x + 1] = i;
+				sorted = false;
+			}
+		}
+	}
+
+	// Return the first one that doesn't fail to initialize
+	for (int x = 0; x < FactoryNextSlot - 1; x++)
+	{
+	}
+	return NULL;
+}
+
 int SoundDriverFactory::EnumDrivers(SoundDriverType *drivers, int max_entries)
 {
 	int retVal = 0;

--- a/AziAudio/SoundDriverFactory.cpp
+++ b/AziAudio/SoundDriverFactory.cpp
@@ -17,14 +17,66 @@ SoundDriverFactory::FactoryDriversStruct SoundDriverFactory::FactoryDrivers[MAX_
 SoundDriverInterface* SoundDriverFactory::CreateSoundDriver(SoundDriverType DriverID)
 {
 	SoundDriverInterface *result = NULL;
+	SoundDriverType drivers[MAX_FACTORY_DRIVERS];
+	int index[MAX_FACTORY_DRIVERS];
+	bool sorted = false;
+
+	// Look for our driver
 	for (int x = 0; x < FactoryNextSlot; x++)
 	{
 		if (FactoryDrivers[x].DriverType == DriverID)
 		{
 			result = FactoryDrivers[x].CreateFunction();
-			break;
+			if (result != NULL)
+				break;
 		}
 	}
+
+	/*
+		We have two options here.  See if the Validate is enough to prevent a "NoSound" situation or we need to rework AI_Startup and Initialize.
+		Pros for Validate - We remove the need to do an API overhaul for something that should happen seldomly.
+		Cons for Validate - It doesn't exactly fix a scenario where the API is available but fails to initialize.
+
+		I think for now I am happy where things are unless we see issues.  I have a lot of other things to do so it will stay disabled for now.
+	*/
+#if 0 
+	if (result == NULL)
+	{
+		// *** Start failover ***
+		// Copy the drivers
+		for (int x = 0; x < FactoryNextSlot; x++)
+		{
+			drivers[x] = FactoryDrivers[x].DriverType;
+			index[x] = x;
+		}
+
+		// Sort on priority -- Highest priority is likely best API for the system
+		while (sorted == false)
+		{
+			sorted = true;
+			for (int x = 0; x < FactoryNextSlot - 1; x++)
+			{
+				if (FactoryDrivers[index[x]].Priority <
+					FactoryDrivers[index[x + 1]].Priority)
+				{
+					int i;
+					i = index[x];
+					index[x] = index[x + 1];
+					index[x + 1] = i;
+					sorted = false;
+				}
+			}
+		}
+
+		// Return the first one that doesn't fail to initialize
+		for (int x = 0; x < FactoryNextSlot; x++)
+		{
+			result = FactoryDrivers[index[x]].CreateFunction();
+			if (result != NULL)
+				break;
+		}
+	}
+#endif
 	if (result == NULL)
 		result = new NoSoundDriver();
 
@@ -63,44 +115,6 @@ SoundDriverType SoundDriverFactory::DefaultDriver()
 		}
 	}
 	return retVal;
-}
-
-SoundDriverInterface* SoundDriverFactory::FailoverDriver()
-{
-	SoundDriverType drivers[MAX_FACTORY_DRIVERS];
-	int index[MAX_FACTORY_DRIVERS];
-	bool sorted = false;
-
-	// Copy the drivers
-	for (int x = 0; x < FactoryNextSlot; x++)
-	{
-		drivers[x] = FactoryDrivers[x].DriverType;
-		index[x] = x;
-	}
-
-	// Sort on priority
-	while (sorted == false)
-	{
-		sorted = true;
-		for (int x = 0; x < FactoryNextSlot-1; x++)
-		{
-			if (FactoryDrivers[index[x]].Priority <
-				FactoryDrivers[index[x+1]].Priority)
-			{
-				int i;
-				i = index[x];
-				index[x] = index[x + 1];
-				index[x + 1] = i;
-				sorted = false;
-			}
-		}
-	}
-
-	// Return the first one that doesn't fail to initialize
-	for (int x = 0; x < FactoryNextSlot - 1; x++)
-	{
-	}
-	return NULL;
 }
 
 int SoundDriverFactory::EnumDrivers(SoundDriverType *drivers, int max_entries)

--- a/AziAudio/SoundDriverFactory.h
+++ b/AziAudio/SoundDriverFactory.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverFactory.h
+++ b/AziAudio/SoundDriverFactory.h
@@ -29,6 +29,7 @@ private:
 	static int FactoryNextSlot;
 	static const int MAX_FACTORY_DRIVERS = 20;
 	static FactoryDriversStruct FactoryDrivers[MAX_FACTORY_DRIVERS];
+	static SoundDriverInterface* FailoverDriver();
 public:
 	~SoundDriverFactory() {};
 

--- a/AziAudio/SoundDriverFactory.h
+++ b/AziAudio/SoundDriverFactory.h
@@ -29,7 +29,6 @@ private:
 	static int FactoryNextSlot;
 	static const int MAX_FACTORY_DRIVERS = 20;
 	static FactoryDriversStruct FactoryDrivers[MAX_FACTORY_DRIVERS];
-	static SoundDriverInterface* FailoverDriver();
 public:
 	~SoundDriverFactory() {};
 

--- a/AziAudio/SoundDriverInterface.cpp
+++ b/AziAudio/SoundDriverInterface.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverInterface.h
+++ b/AziAudio/SoundDriverInterface.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverLegacy.cpp
+++ b/AziAudio/SoundDriverLegacy.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/SoundDriverLegacy.h
+++ b/AziAudio/SoundDriverLegacy.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/WASAPISoundDriver.cpp
+++ b/AziAudio/WASAPISoundDriver.cpp
@@ -18,8 +18,9 @@
 #include <audioclient.h>
 #include <mmdeviceapi.h>
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_WASAPI, WASAPISoundDriver::CreateSoundDriver, "WASAPI Driver (experimental)", 0);
-
+bool WASAPISoundDriver::ClassRegistered = WASAPISoundDriver::ValidateDriver() ?
+					SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_WASAPI, WASAPISoundDriver::CreateSoundDriver, "WASAPI Driver (experimental)", 0) :
+					false;
 // REFERENCE_TIME time units per second and per millisecond
 #define REFTIMES_PER_SEC  10000000
 #define REFTIMES_PER_MILLISEC  10000
@@ -35,6 +36,10 @@ const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
 const IID IID_IAudioClient = __uuidof(IAudioClient);
 const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
 
+bool WASAPISoundDriver::ValidateDriver()
+{
+	return true;
+}
 
 WASAPISoundDriver::WASAPISoundDriver()
 {

--- a/AziAudio/WASAPISoundDriver.cpp
+++ b/AziAudio/WASAPISoundDriver.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
@@ -38,7 +38,22 @@ const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
 
 bool WASAPISoundDriver::ValidateDriver()
 {
-	return true;
+	bool retVal = false;
+	/* Validate a windows audio services end point enumerator object will initialize */
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	const GUID CLSID_MMDeviceEnumerator_Test = { 0xBCDE0395, 0xE52F, 0x467C, 0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E };
+	const GUID IID_IMMDeviceEnumerator_Test = { 0xA95664D2, 0x9614, 0x4F35, 0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6 };
+	IUnknown* obj;
+
+	HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator_Test,
+		NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator_Test, (void**)&obj);
+	if (SUCCEEDED(hr))
+	{
+		obj->Release();
+		retVal = true;
+	}
+	CoUninitialize();
+	return retVal;
 }
 
 WASAPISoundDriver::WASAPISoundDriver()

--- a/AziAudio/WASAPISoundDriver.h
+++ b/AziAudio/WASAPISoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/WASAPISoundDriver.h
+++ b/AziAudio/WASAPISoundDriver.h
@@ -46,6 +46,8 @@ public:
 	// Override the default in SoundDriver
 	//u32 WASAPISoundDriver::LoadAiBuffer(u8 *start, u32 length);
 
+	static bool ValidateDriver();
+
 protected:
 	static DWORD WINAPI WASAPISoundDriver::AudioThreadProc(LPVOID lpParameter);
 
@@ -57,6 +59,7 @@ private:
 	HANDLE hAudioThread;
 	bool   bStopAudioThread;
 	bool   m_CoUninit;
+	static bool ClassRegistered;
 };
 
 #if !defined(_MSC_VER)

--- a/AziAudio/WaveOut.cpp
+++ b/AziAudio/WaveOut.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/WaveOut.h
+++ b/AziAudio/WaveOut.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/WaveOutSoundDriver.cpp
+++ b/AziAudio/WaveOutSoundDriver.cpp
@@ -19,10 +19,20 @@
 #pragma comment(lib, "winmm.lib")
 
 #if 1 /* Disable this driver */
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_WAVEOUT, WaveOutSoundDriver::CreateSoundDriver, "WaveOut Driver", 1);
+bool WaveOutSoundDriver::ClassRegistered = ValidateDriver() ?
+		SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_WAVEOUT, WaveOutSoundDriver::CreateSoundDriver, "WaveOut Driver", 1) :
+		false;
 #endif
 
 static WaveOutSoundDriver* m_Instance; // TODO:  Find an alternative to a static class point
+
+/*
+	Will verify the driver can run in the configured environment
+*/
+bool WaveOutSoundDriver::ValidateDriver()
+{
+	return true;
+}
 
 WaveOutSoundDriver::WaveOutSoundDriver()
 {

--- a/AziAudio/WaveOutSoundDriver.h
+++ b/AziAudio/WaveOutSoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
@@ -48,6 +48,8 @@ public:
 protected:
 
 	static void CALLBACK waveOutProc(HWAVEOUT hwo, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2);
+
+	static WaveOutSoundDriver* m_Instance;
 	HWAVEOUT       m_hWave;
 
 	int m_numOutputBuffers;

--- a/AziAudio/WaveOutSoundDriver.h
+++ b/AziAudio/WaveOutSoundDriver.h
@@ -43,6 +43,7 @@ public:
 	void SetVolume(u32 volume);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new WaveOutSoundDriver(); }
+	static bool ValidateDriver();
 
 protected:
 
@@ -57,6 +58,7 @@ protected:
 	u32 SampleRate;
 
 private:
+	static bool ClassRegistered;
 };
 
 #if !defined(_MSC_VER)

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
@@ -40,7 +40,22 @@ static VoiceCallback voiceCallback;
 
 bool XAudio2SoundDriver::ValidateDriver()
 {
-	return true;
+	bool retVal = false;
+	/* Validate an XAudio2 2.7 object will initialize */
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	const GUID CLSID_XAudio2_Test = { 0x5a508685, 0xa254, 0x4fba, 0x9b, 0x82, 0x9a, 0x24, 0xb0, 0x03, 0x06, 0xaf };
+	const GUID IID_IXAudio2_Test = { 0x8bcf1f58, 0x9fe7, 0x4583, 0x8a, 0xc6, 0xe2, 0xad, 0xc4, 0x65, 0xc8, 0xbb };
+	IUnknown* obj;
+
+	HRESULT hr = CoCreateInstance(CLSID_XAudio2_Test,
+		NULL, CLSCTX_INPROC_SERVER, IID_IXAudio2_Test, (void**)&obj);
+	if (SUCCEEDED(hr))
+	{
+		obj->Release();
+		retVal = true;
+	}
+	CoUninitialize();
+	return retVal;
 }
 
 XAudio2SoundDriver::XAudio2SoundDriver()

--- a/AziAudio/XAudio2SoundDriver.cpp
+++ b/AziAudio/XAudio2SoundDriver.cpp
@@ -16,7 +16,9 @@
 #include <stdio.h>
 #include "SoundDriverFactory.h"
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_XA2, XAudio2SoundDriver::CreateSoundDriver, "XAudio2 Driver", 15);
+bool XAudio2SoundDriver::ClassRegistered = ValidateDriver() ?
+		SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_XA2, XAudio2SoundDriver::CreateSoundDriver, "XAudio2 Driver", 15) :
+		false;
 
 static IXAudio2* g_engine;
 static IXAudio2SourceVoice* g_source;
@@ -35,6 +37,11 @@ static int lastLength = 1;
 static int cacheSize = 0;
 static int interrupts = 0;
 static VoiceCallback voiceCallback;
+
+bool XAudio2SoundDriver::ValidateDriver()
+{
+	return true;
+}
 
 XAudio2SoundDriver::XAudio2SoundDriver()
 {

--- a/AziAudio/XAudio2SoundDriver.h
+++ b/AziAudio/XAudio2SoundDriver.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/XAudio2SoundDriver.h
+++ b/AziAudio/XAudio2SoundDriver.h
@@ -76,6 +76,7 @@ public:
 	void SetVolume(u32 volume);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new XAudio2SoundDriver(); }
+	static bool ValidateDriver();
 
 protected:
 
@@ -85,6 +86,7 @@ protected:
 private:
 	HANDLE hAudioThread;
 	bool   bStopAudioThread;
+	static bool ClassRegistered;
 };
 
 /*

--- a/AziAudio/XAudio2SoundDriverLegacy.cpp
+++ b/AziAudio/XAudio2SoundDriverLegacy.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
@@ -42,7 +42,22 @@ static VoiceCallbackLegacy voiceCallback;
 
 bool XAudio2SoundDriverLegacy::ValidateDriver()
 {
-	return true;
+	bool retVal = false;
+	/* Validate an XAudio2 2.7 object will initialize */
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	const GUID CLSID_XAudio2_Test = { 0x5a508685, 0xa254, 0x4fba, 0x9b, 0x82, 0x9a, 0x24, 0xb0, 0x03, 0x06, 0xaf };
+	const GUID IID_IXAudio2_Test = { 0x8bcf1f58, 0x9fe7, 0x4583, 0x8a, 0xc6, 0xe2, 0xad, 0xc4, 0x65, 0xc8, 0xbb };
+	IUnknown* obj;
+
+	HRESULT hr = CoCreateInstance(CLSID_XAudio2_Test,
+		NULL, CLSCTX_INPROC_SERVER, IID_IXAudio2_Test, (void**)&obj);
+	if (SUCCEEDED(hr))
+	{
+		obj->Release();
+		retVal = true;
+	}
+	CoUninitialize();
+	return retVal;
 }
 
 XAudio2SoundDriverLegacy::XAudio2SoundDriverLegacy()

--- a/AziAudio/XAudio2SoundDriverLegacy.cpp
+++ b/AziAudio/XAudio2SoundDriverLegacy.cpp
@@ -16,7 +16,9 @@
 #include <stdio.h>
 #include "SoundDriverFactory.h"
 
-static bool ClassRegistered = SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_XA2L, XAudio2SoundDriverLegacy::CreateSoundDriver, "XAudio2 Legacy Driver", 11);
+bool XAudio2SoundDriverLegacy::ClassRegistered = XAudio2SoundDriverLegacy::ValidateDriver() ?
+		SoundDriverFactory::RegisterSoundDriver(SND_DRIVER_XA2L, XAudio2SoundDriverLegacy::CreateSoundDriver, "XAudio2 Legacy Driver", 11) :
+		false;
 
 static IXAudio2* g_engine;
 static IXAudio2SourceVoice* g_source;
@@ -37,6 +39,12 @@ static int lastLength = 1;
 static int cacheSize = 0;
 static int interrupts = 0;
 static VoiceCallbackLegacy voiceCallback;
+
+bool XAudio2SoundDriverLegacy::ValidateDriver()
+{
+	return true;
+}
+
 XAudio2SoundDriverLegacy::XAudio2SoundDriverLegacy()
 {
 	g_engine = NULL;

--- a/AziAudio/XAudio2SoundDriverLegacy.h
+++ b/AziAudio/XAudio2SoundDriverLegacy.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/XAudio2SoundDriverLegacy.h
+++ b/AziAudio/XAudio2SoundDriverLegacy.h
@@ -77,6 +77,7 @@ public:
 	//void PlayBuffer(int bufferNumber, u8* bufferData, int bufferSize);
 
 	static SoundDriverInterface* CreateSoundDriver() { return new XAudio2SoundDriverLegacy(); }
+	static bool ValidateDriver();
 
 protected:
 
@@ -86,6 +87,7 @@ protected:
 private:
 	HANDLE hAudioThread;
 	bool   bStopAudioThread;
+	static bool ClassRegistered;
 };
 
 /*

--- a/AziAudio/audiohle.h
+++ b/AziAudio/audiohle.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/common.h
+++ b/AziAudio/common.h
@@ -12,7 +12,7 @@
 //************ Configuration Section ************** (to be moved to compile time defines)
 
 // Configure the plugin to have a console window for informational output -- should be used for debugging only
-//#define USE_PRINTF
+#define USE_PRINTF
 
 #ifdef _WIN32
 #define ENABLE_BACKEND_DIRECTSOUND8_LEGACY

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -2,7 +2,7 @@
 *                                                                           *
 * Azimer's HLE Audio Plugin for Project64 Compatible N64 Emulators          *
 * http://www.apollo64.com/                                                  *
-* Copyright (C) 2000-2017 Azimer. All rights reserved.                      *
+* Copyright (C) 2000-2019 Azimer. All rights reserved.                      *
 *                                                                           *
 * License:                                                                  *
 * GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *

--- a/AziAudio/main.cpp
+++ b/AziAudio/main.cpp
@@ -33,6 +33,8 @@ SoundDriverInterface *snd = NULL;
 bool ai_delayed_carry;  // Borrowed from MAME and Mupen64Plus
 bool bBackendChanged = false;
 
+void SetTimerResolution(void);
+
 #ifdef USE_PRINTF
   void RedirectIOToConsole();
 #endif
@@ -105,6 +107,11 @@ EXPORT Boolean CALL InitiateAudio(AUDIO_INFO Audio_Info) {
 #endif
 	Dacrate = 0;
 	//CloseDLL ();
+
+	if (Configuration::getResTimer() == true)
+	{
+		SetTimerResolution();
+	}
 
 	memcpy(&AudioInfo, &Audio_Info, sizeof(AUDIO_INFO));
 	DRAM = Audio_Info.RDRAM;
@@ -328,5 +335,25 @@ void RedirectIOToConsole() {
 	
 #endif
 }
+
+
+#ifdef _WIN32
+/*
+	Time resolution code borrowed from Project64-Audio
+	Will be set as an optional parameter
+ 
+ */
+void SetTimerResolution(void)
+{
+	HMODULE hMod = GetModuleHandle("ntdll.dll");
+	if (hMod != NULL)
+	{
+		typedef LONG(NTAPI* tNtSetTimerResolution)(IN ULONG DesiredResolution, IN BOOLEAN SetResolution, OUT PULONG CurrentResolution);
+		tNtSetTimerResolution NtSetTimerResolution = (tNtSetTimerResolution)GetProcAddress(hMod, "NtSetTimerResolution");
+		ULONG CurrentResolution = 0;
+		NtSetTimerResolution(10000, TRUE, &CurrentResolution);
+	}
+}
+#endif
 
 #endif


### PR DESCRIPTION
* Added a validation method each driver
* Added Resolution Timer (optional - off by default).  Not added to configuration yet.
* Updated copyright for 2019
* Minimum buffer/frames for waveOut to prevent stuttering
* Implemented then removed driver failover.  I believe the validation will handle 80% of issues.
* Removed DirectSound Legacy "Streaming".  It doesn't appear to be working well enough to leave in.
* Found a bug where DirectSound was using the FPS value and not BackendFPS value.